### PR TITLE
Fix doctests

### DIFF
--- a/pyrealm/hygro.py
+++ b/pyrealm/hygro.py
@@ -37,15 +37,15 @@ def calc_vp_sat(ta: NDArray, const: HygroConst = HygroConst()) -> NDArray:
         >>> # Saturated vapour pressure at 21°C
         >>> import numpy as np
         >>> temp = np.array([21])
-        >>> round(calc_vp_sat(temp), 6)
-        2.480904
+        >>> calc_vp_sat(temp).round(6)
+        array([2.480904])
         >>> from pyrealm.constants import HygroConst
         >>> allen = HygroConst(magnus_option='Allen1998')
-        >>> round(calc_vp_sat(temp, const=allen), 6)
-        2.487005
+        >>> calc_vp_sat(temp, const=allen).round(6)
+        array([2.487005])
         >>> alduchov = HygroConst(magnus_option='Alduchov1996')
-        >>> round(calc_vp_sat(temp, const=alduchov), 6)
-        2.481888
+        >>> calc_vp_sat(temp, const=alduchov).round(6)
+        array([2.481888])
     """
 
     # Magnus equation and conversion to kPa
@@ -71,14 +71,14 @@ def convert_vp_to_vpd(
 
     Examples:
         >>> import numpy as np
+        >>> from pyrealm.constants import HygroConst
         >>> vp = np.array([1.9])
         >>> temp = np.array([21])
-        >>> round(convert_vp_to_vpd(vp, temp), 7)
-        0.5809042
-        >>> from pyrealm.constants import HygroConst
+        >>> convert_vp_to_vpd(vp, temp).round(7)
+        array([0.5809042])
         >>> allen = HygroConst(magnus_option='Allen1998')
-        >>> round(convert_vp_to_vpd(vp, temp, const=allen), 7)
-        0.5870054
+        >>> convert_vp_to_vpd(vp, temp, const=allen).round(7)
+        array([0.5870054])
     """
     vp_sat = calc_vp_sat(ta, const=const)
 
@@ -101,19 +101,19 @@ def convert_rh_to_vpd(
 
     Examples:
         >>> import numpy as np
+        >>> from pyrealm.constants import HygroConst
+        >>> import sys; sys.stderr = sys.stdout
         >>> rh = np.array([0.7])
         >>> temp = np.array([21])
-        >>> round(convert_rh_to_vpd(rh, temp), 7)
-        0.7442712
-        >>> from pyrealm.constants import HygroConst
+        >>> convert_rh_to_vpd(rh, temp).round(7)
+        array([0.7442712])
         >>> allen = HygroConst(magnus_option='Allen1998')
-        >>> round(convert_rh_to_vpd(rh, temp, hygro_params=allen), 7)
-        0.7461016
-        >>> import sys; sys.stderr = sys.stdout
+        >>> convert_rh_to_vpd(rh, temp, const=allen).round(7)
+        array([0.7461016])
         >>> rh_percent = np.array([70])
-        >>> round(convert_rh_to_vpd(rh_percent, temp), 7) #doctest: +ELLIPSIS
+        >>> convert_rh_to_vpd(rh_percent, temp).round(7) #doctest: +ELLIPSIS
         pyrealm... contains values outside the expected range (0,1). Check units?
-        -171.1823864
+        array([-171.1823864])
     """
 
     rh = bounds_checker(rh, 0, 1, "[]", "rh", "proportion")
@@ -141,8 +141,8 @@ def convert_sh_to_vp(
         >>> import numpy as np
         >>> sh = np.array([0.006])
         >>> patm = np.array([99.024])
-        >>> round(convert_sh_to_vp(sh, patm), 7)
-        0.9517451
+        >>> convert_sh_to_vp(sh, patm).round(7)
+        array([0.9517451])
     """
 
     return sh * patm / ((1.0 - const.mwr) * sh + const.mwr)
@@ -165,15 +165,15 @@ def convert_sh_to_vpd(
 
     Examples:
         >>> import numpy as np
+        >>> from pyrealm.constants import HygroConst
         >>> sh = np.array([0.006])
         >>> temp = np.array([21])
         >>> patm = np.array([99.024])
-        >>> round(convert_sh_to_vpd(sh, temp, patm), 6)
-        1.529159
-        >>> from pyrealm.constants import HygroConst
+        >>> convert_sh_to_vpd(sh, temp, patm).round(6)
+        array([1.529159])
         >>> allen = HygroConst(magnus_option='Allen1998')
-        >>> round(convert_sh_to_vpd(sh, temp, patm, hygro_params=allen), 5)
-        1.53526
+        >>> convert_sh_to_vpd(sh, temp, patm, const=allen).round(5)
+        array([1.53526])
     """
 
     vp_sat = calc_vp_sat(ta, const=const)

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -50,7 +50,7 @@ def calc_density_h2o(
     # It doesn't make sense to use this function for tc < 0, but in particular
     # the calculation shows wild numeric instability between -44 and -46 that
     # leads to numerous downstream issues - see the extreme values documentation.
-    if safe and np.nanmin(tc) < -30:
+    if safe and np.nanmin(tc) < np.array([-30]):
         raise ValueError(
             "Water density calculations below about -30°C are "
             "unstable. See argument safe to calc_density_h2o"
@@ -493,8 +493,9 @@ def calc_kp_c4(
     Examples:
         >>> # Michaelis-Menten coefficient at 20 degrees Celsius and standard
         >>> # atmosphere (in Pa):
-        >>> round(calc_kp_c4(20, 101325), 5)
-        9.26352
+        >>> import numpy as np
+        >>> calc_kp_c4(np.array([20]), np.array([101325])).round(5)
+        array([12.46385])
     """
 
     # Check inputs, return shape not used
@@ -566,10 +567,9 @@ def calc_soilmstress_stocker(
         A numeric value or values for :math:`\beta`
 
     Examples:
-        >>> # Relative reduction (%) in GPP due to soil moisture stress at
-        >>> # relative soil water content ('soilm') of 0.2:
-        >>> round((calc_soilmstress(0.2) - 1) * 100, 5)
-        -11.86667
+        >>> # Proportion of well-watered GPP available at soil moisture of 0.2
+        >>> calc_soilmstress_stocker(np.array([0.2])).round(5)
+        array([0.88133])
     """
 
     # TODO - move soilm params into standalone param class for this function -
@@ -645,7 +645,11 @@ def calc_soilmstress_mengoli(
         A numeric value or values for :math:`f(\theta)`
 
     Examples:
-        >>> TODO
+        >>> import numpy as np
+        >>> # Proportion of well-watered GPP available with soil moisture and aridity
+        >>> # index values of 0.6
+        >>> calc_soilmstress_mengoli(np.array([0.6]), np.array([0.6])).round(5)
+        array([0.78023])
     """
 
     # TODO - move soilm params into standalone param class for this function -

--- a/pyrealm/pmodel/isotopes.py
+++ b/pyrealm/pmodel/isotopes.py
@@ -106,15 +106,18 @@ class CalcCarbonIsotopes:
         :cite:p:`lavergne:2022a`.
 
         Examples:
-            >>> ppar = PModelParams(beta_cost_ratio_c4=35)
-            >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,
-            ...                         vpd=1000, const=ppar)
+            >>> import numpy as np
+            >>> from pyrealm.pmodel import PModel, PModelEnvironment
+            >>> from pyrealm.constants import PModelConst
+            >>> const = PModelConst(beta_cost_ratio_c4=35)
+            >>> env = PModelEnvironment(tc=np.array([20]), patm=np.array([101325]),
+            ...              co2=np.array([400]), vpd=np.array([1000]), const=const)
             >>> mod_c4 = PModel(env, method_optchi='c4_no_gamma')
             >>> mod_c4_delta = CalcCarbonIsotopes(mod_c4, d13CO2= -8.4, D14CO2 = 19.2)
-            >>> round(mod_c4_delta.Delta13C, 4)
-            5.6636
-            >>> round(mod_c4_delta.d13C_leaf, 4)
-            -13.9844
+            >>> mod_c4_delta.Delta13C.round(4)
+            array([5.6636])
+            >>> mod_c4_delta.d13C_leaf.round(4)
+            array([-13.9844])
         """
 
         # Equation from C3/C4 paper
@@ -136,13 +139,18 @@ class CalcCarbonIsotopes:
         sensitive correction term is provided in commented code but not used.
 
         Examples:
-            >>> ppar = PModelParams(beta_cost_ratio_c4=35)
-            >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,
-            ...                         vpd=1000, const=ppar)
+            >>> import numpy as np
+            >>> from pyrealm.pmodel import PModel, PModelEnvironment
+            >>> from pyrealm.constants import PModelConst
+            >>> const = PModelConst(beta_cost_ratio_c4=35)
+            >>> env = PModelEnvironment(tc=np.array([20]), patm=np.array([101325]),
+            ...              co2=np.array([400]), vpd=np.array([1000]), const=const)
             >>> mod_c4 = PModel(env, method_optchi='c4_no_gamma')
             >>> mod_c4_delta = CalcCarbonIsotopes(mod_c4, d13CO2= -8.4, D14CO2 = 19.2)
-            >>> # round(mod_c4_delta.Delta13C, 4)  # NOT CHECKED 5.2753
-            >>> # round(mod_c4_delta.d13C_leaf, 4)  # NOT CHECKED -13.6036
+            >>> # mod_c4_delta.Delta13C.round(4)
+            >>> # array([5.2753])
+            >>> # mod_c4_delta.d13C_leaf.round(4)
+            >>> # array([-13.6036])
         """
 
         warn("This method is experimental code from Alienor Lavergne")
@@ -173,14 +181,19 @@ class CalcCarbonIsotopes:
         effect following :cite:p:`farquhar:1982a`.
 
         Examples:
-            >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,
-            ...                         vpd=1000, theta=0.4)
+            >>> import numpy as np
+            >>> from pyrealm.pmodel import PModel, PModelEnvironment
+            >>> env = PModelEnvironment(
+            ...              tc=np.array([20]), patm=np.array([101325]),
+            ...              co2=np.array([400]), vpd=np.array([1000]),
+            ...              theta=np.array([0.4])
+            ... )
             >>> mod_c3 = PModel(env, method_optchi='lavergne20_c3')
             >>> mod_c3_delta = CalcCarbonIsotopes(mod_c3, d13CO2= -8.4, D14CO2 = 19.2)
-            >>> round(mod_c3_delta.Delta13C, 4)
-            20.4056
-            >>> round(mod_c3_delta.d13C_leaf, 4)
-            -28.2296
+            >>> mod_c3_delta.Delta13C.round(4)
+            array([20.4056])
+            >>> mod_c3_delta.d13C_leaf.round(4)
+            array([-28.2296])
         """
 
         # 13C discrimination (permil): Farquhar et al. (1982)

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -109,14 +109,14 @@ class PModelEnvironment:
         """Atmospheric pressure, Pa"""
 
         # Guard against calc_density issues
-        if np.nanmin(self.tc) < -25:
+        if np.nanmin(self.tc) < np.array([-25]):
             raise ValueError(
                 "Cannot calculate P Model predictions for values below"
                 " -25°C. See calc_density_h2o."
             )
 
         # Guard against negative VPD issues
-        if np.nanmin(self.vpd) < 0:
+        if np.nanmin(self.vpd) < np.array([0]):
             raise ValueError(
                 "Negative VPD values will lead to missing data - clip to "
                 "zero or explicitly set to np.nan"
@@ -309,25 +309,29 @@ class PModel:
             :func:`~pyrealm.pmodel.functions.calc_ftemp_kphio`).
 
     Examples:
-        >>> env = PModelEnvironment(tc=20, vpd=1000, co2=400, patm=101325.0)
+        >>> import numpy as np
+        >>> env = PModelEnvironment(
+        ...     tc=np.array([20]), vpd=np.array([1000]),
+        ...     co2=np.array([400]), patm=np.array([101325.0])
+        ... )
+        >>> # Predictions from C3 P model
         >>> mod_c3 = PModel(env)
-        >>> # Key variables from pmodel
-        >>> np.round(mod_c3.optchi.ci, 5)
-        28.14209
-        >>> np.round(mod_c3.optchi.chi, 5)
-        0.69435
+        >>> mod_c3.optchi.ci.round(5)
+        array([28.14209])
+        >>> mod_c3.optchi.chi.round(5)
+        array([0.69435])
         >>> mod_c3.estimate_productivity(fapar=1, ppfd=300)
-        >>> np.round(mod_c3.gpp, 5)
-        76.42545
+        >>> mod_c3.gpp.round(5)
+        array([76.42545])
+        >>> # Predictions from C4 P model
         >>> mod_c4 = PModel(env, method_optchi='c4', method_jmaxlim='none')
-        >>> # Key variables from PModel
-        >>> np.round(mod_c4.optchi.ci, 5)
-        18.22528
-        >>> np.round(mod_c4.optchi.chi, 5)
-        0.44967
+        >>> mod_c4.optchi.ci.round(5)
+        array([18.22528])
+        >>> mod_c4.optchi.chi.round(5)
+        array([0.44967])
         >>> mod_c4.estimate_productivity(fapar=1, ppfd=300)
-        >>> np.round(mod_c4.gpp, 5)
-        103.25886
+        >>> mod_c4.gpp.round(5)
+        array([103.25886])
     """
 
     def __init__(
@@ -796,16 +800,20 @@ class CalcOptimalChi:
         assimilation.
 
         Examples:
-            >>> env = PModelEnvironment(tc= 20, patm=101325, co2=400, vpd=1000)
+            >>> import numpy as np
+            >>> env = PModelEnvironment(
+            ...     tc=np.array([20]), vpd=np.array([1000]),
+            ...     co2=np.array([400]), patm=np.array([101325.0])
+            ... )
             >>> vals = CalcOptimalChi(env=env)
-            >>> round(vals.chi, 5)
-            0.69435
-            >>> round(vals.mc, 5)
-            0.33408
-            >>> round(vals.mj, 5)
-            0.7123
-            >>> round(vals.mjoc, 5)
-            2.13211
+            >>> vals.chi.round(5)
+            array([0.69435])
+            >>> vals.mc.round(5)
+            array([0.33408])
+            >>> vals.mj.round(5)
+            array([0.7123])
+            >>> vals.mjoc.round(5)
+            array([2.13211])
         """
 
         # TODO: Docstring - equation for m_j previously included term now
@@ -854,19 +862,22 @@ class CalcOptimalChi:
         `rootzonestress` approach.
 
         Examples:
-            >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,
-            ...                         vpd=1000, theta=0.5)
+            >>> import numpy as np
+            >>> env = PModelEnvironment(
+            ...     tc=np.array([20]), vpd=np.array([1000]), co2=np.array([400]),
+            ...     patm=np.array([101325.0]), theta=np.array([0.5])
+            ... )
             >>> vals = CalcOptimalChi(env=env, method='lavergne20_c3')
-            >>> round(vals.beta, 5)
-            224.75255
-            >>> round(vals.chi, 5)
-            0.73663
-            >>> round(vals.mc, 5)
-            0.34911
-            >>> round(vals.mj, 5)
-            0.7258
-            >>> round(vals.mjoc, 5)
-            2.07901
+            >>> vals.beta.round(5)
+            array([224.75255])
+            >>> vals.chi.round(5)
+            array([0.73663])
+            >>> vals.mc.round(5)
+            array([0.34911])
+            >>> vals.mj.round(5)
+            array([0.7258])
+            >>> vals.mjoc.round(5)
+            array([2.07901])
         """
 
         # This method needs theta
@@ -924,19 +935,22 @@ class CalcOptimalChi:
         values and soil moisture in leaf gas exchange measurements.
 
         Examples:
-            >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,
-            ...                         vpd=1000, theta=0.5)
+            >>> import numpy as np
+            >>> env = PModelEnvironment(
+            ...     tc=np.array([20]), vpd=np.array([1000]), co2=np.array([400]),
+            ...     patm=np.array([101325.0]), theta=np.array([0.5])
+            ... )
             >>> vals = CalcOptimalChi(env=env, method='lavergne20_c4')
-            >>> round(vals.beta, 5)
-            24.97251
-            >>> round(vals.chi, 5)
-            0.44432
-            >>> round(vals.mc, 5)
-            0.28091
-            >>> round(vals.mj, 5)
-            1.0
-            >>> round(vals.mjoc, 5)
-            3.55989
+            >>> vals.beta.round(5)
+            array([24.97251])
+            >>> vals.chi.round(5)
+            array([0.44432])
+            >>> vals.mc.round(5)
+            array([0.28091])
+            >>> vals.mj.round(5)
+            array([1.])
+            >>> vals.mjoc.round(5)
+            array([3.55989])
         """
 
         # Warn that this is experimental
@@ -982,14 +996,18 @@ class CalcOptimalChi:
         photosynthesis.
 
         Examples:
-            >>> env = PModelEnvironment(tc= 20, patm=101325, co2=400, vpd=1000)
+            >>> import numpy as np
+            >>> env = PModelEnvironment(
+            ...     tc=np.array([20]), vpd=np.array([1000]), co2=np.array([400]),
+            ...     patm=np.array([101325.0]), theta=np.array([0.5])
+            ... )
             >>> vals = CalcOptimalChi(env=env, method='c4')
-            >>> round(vals.chi, 5)
-            0.44967
-            >>> round(vals.mj, 1)
-            1.0
-            >>> round(vals.mc, 1)
-            1.0
+            >>> vals.chi.round(5)
+            array([0.44967])
+            >>> vals.mj.round(1)
+            array([1.])
+            >>> vals.mc.round(1)
+            array([1.])
         """
 
         # Replace missing rootzonestress with 1
@@ -1046,14 +1064,18 @@ class CalcOptimalChi:
             \]
 
         Examples:
-            >>> env = PModelEnvironment(tc= 20, patm=101325, co2=400, vpd=1000)
+            >>> import numpy as np
+            >>> env = PModelEnvironment(
+            ...     tc=np.array([20]), vpd=np.array([1000]),
+            ...     co2=np.array([400]), patm=np.array([101325.0])
+            ... )
             >>> vals = CalcOptimalChi(env=env, method='c4_no_gamma')
-            >>> round(vals.chi, 5)
-            0.3919
-            >>> round(vals.mj, 1)
-            1.0
-            >>> round(vals.mc, 1)
-            0.3
+            >>> vals.chi.round(5)
+            array([0.3919])
+            >>> vals.mj.round(1)
+            array([1.])
+            >>> vals.mc.round(1)
+            array([0.3])
         """
 
         # Replace missing rootzonestress with 1
@@ -1127,23 +1149,27 @@ class JmaxLimitation:
         const: An instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
 
     Examples:
-        >>> env = PModelEnvironment(tc= 20, patm=101325, co2=400, vpd=1000)
+        >>> import numpy as np
+        >>> env = PModelEnvironment(
+        ...     tc=np.array([20]), vpd=np.array([1000]),
+        ...     co2=np.array([400]), patm=np.array([101325.0])
+        ... )
         >>> optchi = CalcOptimalChi(env)
         >>> simple = JmaxLimitation(optchi, method='simple')
         >>> simple.f_j
-        1.0
+        array([1.])
         >>> simple.f_v
-        1.0
+        array([1.])
         >>> wang17 = JmaxLimitation(optchi, method='wang17')
-        >>> round(wang17.f_j, 5)
-        0.66722
-        >>> round(wang17.f_v, 5)
-        0.55502
+        >>> wang17.f_j.round(5)
+        array([0.66722])
+        >>> wang17.f_v.round(5)
+        array([0.55502])
         >>> smith19 = JmaxLimitation(optchi, method='smith19')
-        >>> round(smith19.f_j, 5)
-        1.10204
-        >>> round(smith19.f_v, 5)
-        0.75442
+        >>> smith19.f_j.round(5)
+        array([1.10204])
+        >>> smith19.f_v.round(5)
+        array([0.75442])
     """
 
     # TODO - apparent incorrectness of wang and smith methods with _ca_ variation,

--- a/pyrealm/utilities.py
+++ b/pyrealm/utilities.py
@@ -70,7 +70,7 @@ def check_input_shapes(*args: Union[float, int, np.generic, np.ndarray, None]) -
         >>> check_input_shapes(np.array([1,2,3]), 5)
         (3,)
         >>> check_input_shapes(4, 5)
-        1
+        (1,)
         >>> check_input_shapes(np.array([1,2,3]), np.array([1,2]))
         Traceback (most recent call last):
         ...
@@ -284,13 +284,13 @@ def bounds_mask(
         >>> vals = np.array([-15, 20, 30, 124], dtype=np.float)
         >>> np.nansum(vals)
         159.0
-        >>> vals_c = input_mask(vals, 0, 100, label='temperature')
+        >>> vals_c = bounds_mask(vals, 0, 100, label='temperature')
         >>> np.nansum(vals_c)
         50.0
-        >>> vals_c = input_mask(vals, 0, 124, interval_type='[]', label='temperature')
+        >>> vals_c = bounds_mask(vals, 0, 124, interval_type='[]', label='temperature')
         >>> np.nansum(vals_c)
         174.0
-        >>> vals_c = input_mask(vals, 0, 124, interval_type='[)', label='temperature')
+        >>> vals_c = bounds_mask(vals, 0, 124, interval_type='[)', label='temperature')
         >>> np.nansum(vals_c)
         50.0
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ addopts =
 	--doctest-modules 
 	--ignore=pyrealm/__main__.py
 	--ignore=tests/pmodel/generate_test_inputs.py
-testpaths = tests
+testpaths = tests pyrealm
 python_files = test_*.py
 
 [mypy]


### PR DESCRIPTION
This closes #90 by:

* reimplementing the doctests by editing `setup.cfg` to look in `tests` and `pyrealm`.
* fixing all the accumulated broken doctests, which are mostly just changed arg names and array not scalar return types.