### PR TITLE
Update of water density and viscosity functions

### DIFF
--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -130,6 +130,9 @@ class PModelConst(ConstantsClass):
     k_CtoK: float = 273.15
     """Conversion from °C to K   (:math:`CtoK` , 273.15, -)"""
 
+    water_density_method: str = "fisher"
+    """Set the method used for calculating water density ('fisher' or 'chen'."""
+
     # Fisher Dial
     fisher_dial_lambda: NDArray[np.float32] = np.array(
         [1788.316, 21.55053, -0.4695911, 0.003096363, -7.341182e-06]

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -17,11 +17,17 @@ class PModelConst(ConstantsClass):
     value and units shown in brackets and the sources for default parameterisations are
     given below:
 
-    * **Density of water**. Values for the Tumlirz equation taken from Table 5 of
-      :cite:t:`Fisher:1975tm`:
+    * **Density of water using Fisher**. Values for the Tumlirz equation taken from
+      Table 5 of :cite:t:`Fisher:1975tm`:
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.fisher_dial_lambda`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.fisher_dial_Po`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.fisher_dial_Vinf`)
+
+    * **Density of water using Chen**. Values taken from  :cite:t:`chen:2008a`:
+      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.chen_po`,
+      :attr:`~pyrealm.constants.pmodel_const.PModelConst.chen_ko`,
+      :attr:`~pyrealm.constants.pmodel_const.PModelConst.chen_ca`,
+      :attr:`~pyrealm.constants.pmodel_const.PModelConst.chen_cb`)
 
     * **Viscosity of water**. Values for the parameterisation taken from Table 2 and 3
       of :cite:t:`Huber:2009fy`:
@@ -153,6 +159,38 @@ class PModelConst(ConstantsClass):
     )
     r"""Temperature dependent Vinf parameterisation of the Tumlirz equation
     (:math:`V_{\infty}`)."""
+
+    # Chen water density
+    chen_po: NDArray[np.float32] = np.array(
+        [
+            0.99983952,
+            6.788260e-5,
+            -9.08659e-6,
+            1.022130e-7,
+            -1.35439e-9,
+            1.471150e-11,
+            -1.11663e-13,
+            5.044070e-16,
+            -1.00659e-18,
+        ]
+    )
+    r"""Polynomial relationship of water density at 1 atm (kg/m^3) with temperature."""
+
+    chen_ko: NDArray[np.float32] = np.array(
+        [19652.17, 148.1830, -2.29995, 0.01281, -4.91564e-5, 1.035530e-7]
+    )
+    r"""Polynomial relationship of bulk modulus of water at 1 atm (kg/m^3) with
+     temperature."""
+
+    chen_ca: NDArray[np.float32] = np.array(
+        [3.26138, 5.223e-4, 1.324e-4, -7.655e-7, 8.584e-10]
+    )
+    r"""Polynomial temperature dependent coefficient :math:`c_{a}."""
+
+    chen_cb: NDArray[np.float32] = np.array(
+        [7.2061e-5, -5.8948e-6, 8.69900e-8, -1.0100e-9, 4.3220e-12]
+    )
+    r"""Polynomial temperature dependent coefficient :math:`c_{b}."""
 
     # Huber
     simple_viscosity: bool = False

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -188,12 +188,12 @@ class PModelConst(ConstantsClass):
     chen_ca: NDArray[np.float32] = np.array(
         [3.26138, 5.223e-4, 1.324e-4, -7.655e-7, 8.584e-10]
     )
-    r"""Polynomial temperature dependent coefficient :math:`c_{a}."""
+    r"""Polynomial temperature dependent coefficient :math:`c_{a}`."""
 
     chen_cb: NDArray[np.float32] = np.array(
         [7.2061e-5, -5.8948e-6, 8.69900e-8, -1.0100e-9, 4.3220e-12]
     )
-    r"""Polynomial temperature dependent coefficient :math:`c_{b}."""
+    r"""Polynomial temperature dependent coefficient :math:`c_{b}`."""
 
     # Huber
     simple_viscosity: bool = False

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -165,7 +165,6 @@ def calc_density_h2o(
     tc: NDArray,
     patm: NDArray,
     const: PModelConst = PModelConst(),
-    method: str = "fisher",
     safe: bool = True,
 ) -> NDArray:
     """Calculate water density.
@@ -175,10 +174,8 @@ def calc_density_h2o(
     (:func:`~pyrealm.pmodel.functions.calc_density_h20_fisher`) or :cite:t:`chen:2008a`
     (:func:`~pyrealm.pmodel.functions.calc_density_h20_chen`).
 
-    The ``method`` argument can be used to switch between the ``fisher`` and ``chen``
-    methods. This can also be set via the `water_density_method` argument to
-    :class:`~pyrealm.constants.PModelConsts`, which takes priority over the ``method``
-    argument.
+    The `water_density_method` argument to :class:`~pyrealm.constants.PModelConsts` is
+    used to set which of the ``fisher`` or ``chen`` methods is used.
 
     Args:
         tc: air temperature, °C
@@ -209,10 +206,10 @@ def calc_density_h2o(
     # Check input shapes, shape not used
     _ = check_input_shapes(tc, patm)
 
-    if method == "fisher":
+    if const.water_density_method == "fisher":
         return calc_density_h2o_fisher(tc, patm, const)
 
-    if method == "chen":
+    if const.water_density_method == "chen":
         return calc_density_h2o_chen(tc, patm, const)
 
     raise ValueError("Unknown method provided to calc_density_h2o")

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -171,11 +171,12 @@ def calc_density_h2o(
 
     Calculates the density of water as a function of temperature and atmospheric
     pressure. This function uses either the method provided by :cite:t:`Fisher:1975tm`
-    (:func:`~pyrealm.pmodel.functions.calc_density_h20_fisher`) or :cite:t:`chen:2008a`
-    (:func:`~pyrealm.pmodel.functions.calc_density_h20_chen`).
+    (:func:`~pyrealm.pmodel.functions.calc_density_h2o_fisher`) or :cite:t:`chen:2008a`
+    (:func:`~pyrealm.pmodel.functions.calc_density_h2o_chen`).
 
-    The `water_density_method` argument to :class:`~pyrealm.constants.PModelConsts` is
-    used to set which of the ``fisher`` or ``chen`` methods is used.
+    The `water_density_method` argument to
+    :class:`~pyrealm.constants.pmodel_const.PModelConst` is used to set which of the
+    ``fisher`` or ``chen`` methods is used.
 
     Args:
         tc: air temperature, °C

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -19,12 +19,29 @@ def calc_density_h2o_chen(
     This function calculates the density of water at a given temperature and pressure
     (kg/m^3) following :cite:t:`chen:2008a`.
 
+    Warning:
+        The predictions from this function are numerically unstable around -58°C.
+
     Args:
         tc: Air temperature (°C)
         p: Atmospheric pressure (Pa)
+        const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
+
+    PModel Parameters:
+        chen_po: polynomial coefficients of water density equation at 1 atm.
+        chen_ko: polynomial coefficients of bulk modulus at 1 atm.
+        chen_ca: polynomial coefficients of temperature coefficient :math:`c_a`.
+        chen_cb: polynomial coefficients of temperature coefficient :math:`c_b`.
 
     Returns:
-        The calculated density of water
+        Water density as a float in (g cm^-3)
+
+    Raises:
+        ValueError: if the inputs have incompatible shapes.
+
+    Examples:
+        >>> round(calc_density_h2o_chen(20, 101325), 3)
+        998.25
     """
 
     # Calculate density at 1 atm (kg/m^3):
@@ -68,52 +85,10 @@ def calc_density_h2o_chen(
     return pw
 
 
-def calc_density_h2o_chen_matrix(
-    tc: NDArray,
-    patm: NDArray,
-    const: PModelConst = PModelConst(),
-) -> NDArray:
-    """Calculate the density of water using Chen et al 2008.
-
-    This function calculates the density of water at a given temperature and pressure
-    (kg/m^3) following :cite:t:`chen:2008a`.
-
-    Args:
-        tc: Air temperature (°C)
-        p: Atmospheric pressure (Pa)
-
-    Returns:
-        The calculated density of water
-    """
-
-    # TODO - merge
-    tc_pow = np.power.outer(tc, np.arange(0, 9))
-
-    # Calculate density at 1 atm (kg/m^3):
-    rho_ref = np.sum(const.chen_po * tc_pow, axis=-1)
-
-    # Calculate bulk modulus at 1 atm (bar):
-    bulk_mod_ref = np.sum(const.chen_ko * tc_pow[..., :6], axis=-1)
-
-    # Calculate temperature dependent coefficients:
-    ca = np.sum(const.chen_ca * tc_pow[..., :5], axis=-1)
-    cb = np.sum(const.chen_cb * tc_pow[..., :5], axis=-1)
-
-    # Convert atmospheric pressure to bar (1 bar = 100000 Pa)
-    pbar = (1.0e-5) * patm
-
-    return (
-        (bulk_mod_ref + ca * pbar + cb * pbar**2.0)
-        / (bulk_mod_ref + ca * pbar + cb * pbar**2.0 - pbar)
-        * ((1e3) * rho_ref)
-    )
-
-
 def calc_density_h2o_fisher(
     tc: NDArray,
     patm: NDArray,
     const: PModelConst = PModelConst(),
-    safe: bool = True,
 ) -> NDArray:
     """Calculate water density.
 
@@ -121,12 +96,13 @@ def calc_density_h2o_fisher(
     pressure, using the Tumlirz Equation and coefficients calculated by
     :cite:t:`Fisher:1975tm`.
 
+    Warning:
+        The predictions from this function are unstable around -45°C.
+
     Args:
         tc: air temperature, °C
         patm: atmospheric pressure, Pa
         const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-        safe: Prevents the function from estimating density below -30°C, where the
-            function behaves poorly
 
     PModel Parameters:
         lambda_: polynomial coefficients of Tumlirz equation (``fisher_dial_lambda``).
@@ -137,22 +113,12 @@ def calc_density_h2o_fisher(
         Water density as a float in (g cm^-3)
 
     Raises:
-        ValueError: if ``tc`` is less than -30°C and ``safe`` is True, or if the inputs
-            have incompatible shapes.
+        ValueError: if the inputs have incompatible shapes.
 
     Examples:
-        >>> round(calc_density_h2o(20, 101325), 3)
+        >>> round(calc_density_h2o_fisher(20, 101325), 3)
         998.206
     """
-
-    # It doesn't make sense to use this function for tc < 0, but in particular
-    # the calculation shows wild numeric instability between -44 and -46 that
-    # leads to numerous downstream issues - see the extreme values documentation.
-    if safe and np.nanmin(tc) < -30:
-        raise ValueError(
-            "Water density calculations below about -30°C are "
-            "unstable. See argument safe to calc_density_h2o"
-        )
 
     # Check input shapes, shape not used
     _ = check_input_shapes(tc, patm)
@@ -182,78 +148,6 @@ def calc_density_h2o_fisher(
     vinf_val += vinf_coef[7] * tc * tc * tc * tc * tc * tc * tc
     vinf_val += vinf_coef[8] * tc * tc * tc * tc * tc * tc * tc * tc
     vinf_val += vinf_coef[9] * tc * tc * tc * tc * tc * tc * tc * tc * tc
-
-    # Convert pressure to bars (1 bar <- 100000 Pa)
-    pbar = 1e-5 * patm
-
-    # Calculate the specific volume (cm^3 g^-1):
-    spec_vol = vinf_val + lambda_val / (po_val + pbar)
-
-    # Convert to density (g cm^-3) -> 1000 g/kg; 1000000 cm^3/m^3 -> kg/m^3:
-    rho = 1e3 / spec_vol
-
-    return rho
-
-
-def calc_density_h2o_fisher_matrix(
-    tc: NDArray,
-    patm: NDArray,
-    const: PModelConst = PModelConst(),
-    safe: bool = True,
-) -> NDArray:
-    """Calculate water density.
-
-    Calculates the density of water as a function of temperature and atmospheric
-    pressure, using the Tumlirz Equation and coefficients calculated by
-    :cite:t:`Fisher:1975tm`.
-
-    Args:
-        tc: air temperature, °C
-        patm: atmospheric pressure, Pa
-        const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-        safe: Prevents the function from estimating density below -30°C, where the
-            function behaves poorly
-
-    PModel Parameters:
-        lambda_: polynomial coefficients of Tumlirz equation (``fisher_dial_lambda``).
-        Po: polynomial coefficients of Tumlirz equation (``fisher_dial_Po``).
-        Vinf: polynomial coefficients of Tumlirz equation (``fisher_dial_Vinf``).
-
-    Returns:
-        Water density as a float in (g cm^-3)
-
-    Raises:
-        ValueError: if ``tc`` is less than -30°C and ``safe`` is True, or if the inputs
-            have incompatible shapes.
-
-    Examples:
-        >>> round(calc_density_h2o(20, 101325), 3)
-        998.206
-    """
-
-    # It doesn't make sense to use this function for tc < 0, but in particular
-    # the calculation shows wild numeric instability between -44 and -46 that
-    # leads to numerous downstream issues - see the extreme values documentation.
-    if safe and np.nanmin(tc) < np.array([-30]):
-        raise ValueError(
-            "Water density calculations below about -30°C are "
-            "unstable. See argument safe to calc_density_h2o"
-        )
-
-    # Check input shapes, shape not used
-    _ = check_input_shapes(tc, patm)
-
-    # Get powers of tc, including tc^0 = 1 for constant terms
-    tc_pow = np.power.outer(tc, np.arange(0, 10))
-
-    # Calculate lambda, (bar cm^3)/g:
-    lambda_val = np.sum(const.fisher_dial_lambda * tc_pow[..., :5], axis=-1)
-
-    # Calculate po, bar
-    po_val = np.sum(const.fisher_dial_Po * tc_pow[..., :5], axis=-1)
-
-    # Calculate vinf, cm^3/g
-    vinf_val = np.sum(const.fisher_dial_Vinf * tc_pow, axis=-1)
 
     # Convert pressure to bars (1 bar <- 100000 Pa)
     pbar = 1e-5 * patm

--- a/tests/pmodel/test_functions.py
+++ b/tests/pmodel/test_functions.py
@@ -1,0 +1,79 @@
+"""Test the pmodel functions
+
+TODO - note that there are parallel tests in test_pmodel that benchmark against the
+rpmodel outputs and test a wider range of inputs. Those could be moved here. These tests
+check the size of outputs and that the results meet a simple benchmark value.
+"""
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
+def test_calc_density_h20_fisher(shape):
+    """Test the fisher method"""
+    from pyrealm.pmodel.functions import calc_density_h2o_fisher
+
+    rho = calc_density_h2o_fisher(
+        np.full(shape, fill_value=20), np.full(shape, fill_value=101325)
+    )
+
+    assert np.allclose(rho.round(3), np.full(shape, fill_value=998.206))
+
+
+@pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
+def test_calc_density_h20_chen(shape):
+    """Test the chen method"""
+    from pyrealm.pmodel.functions import calc_density_h2o_chen
+
+    rho = calc_density_h2o_chen(
+        np.full(shape, fill_value=20), np.full(shape, fill_value=101325)
+    )
+
+    assert np.allclose(rho.round(3), np.full(shape, fill_value=998.25))
+
+
+@pytest.mark.parametrize(
+    argnames="const_args, exp",
+    argvalues=[
+        pytest.param(None, 998.206, id="defaults"),
+        pytest.param("fisher", 998.206, id="fisher_via_const"),
+        pytest.param("chen", 998.25, id="chen_via_const"),
+    ],
+)
+def test_calc_density_h20(const_args, exp):
+    """Test the wrapper method dispatches as expected"""
+    from pyrealm.constants import PModelConst
+    from pyrealm.pmodel.functions import calc_density_h2o
+
+    args = {}
+
+    if const_args is not None:
+        args["const"] = PModelConst(water_density_method=const_args)
+
+    rho = calc_density_h2o(np.array([20]), np.array([101325]), **args)
+
+    assert rho.round(3) == exp
+
+
+@pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
+def test_calc_viscosity_h20(shape):
+    """Test the viscosity calculation"""
+    from pyrealm.pmodel.functions import calc_viscosity_h2o
+
+    eta = calc_viscosity_h2o(
+        np.full(shape, fill_value=20), np.full(shape, fill_value=101325)
+    )
+
+    assert np.allclose(eta.round(7), np.full(shape, fill_value=0.0010016))
+
+
+@pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
+def test_calc_viscosity_h20_matrix(shape):
+    """Test the viscosity calculation"""
+    from pyrealm.pmodel.functions import calc_viscosity_h2o_matrix
+
+    eta = calc_viscosity_h2o_matrix(
+        np.full(shape, fill_value=20), np.full(shape, fill_value=101325)
+    )
+
+    assert np.allclose(eta.round(7), np.full(shape, fill_value=0.0010016))


### PR DESCRIPTION
Following from the discussion on issue #96 , the current implementation of `calc_density_h2o` and `calc_viscosity_h2o` are slow (and probably memory hungry, although I haven't checked that) as a result of using 'fancy' numpy calls to do outer matrix multiplication and using `np.power` to calculate arrays of powers. Turns out neither of these things is as efficient as I'd though.

This PR:

* Replaces the matrix methods with simpler loops and the power calculations with `tc*tc*tc...` and `tc**n`.
* Adds a new method for water density (Chen et al. 2008), used in some previous applications and added here for benchmarking.
* Converts `calc_density_h2o` into a wrapper around the available individual water density functions.

This closes #96 but possibly only for now - we are still missing well documented really simple methods for these two, although it isn't clear that there _is_ actually a reasonably precise simple function.