### PR TITLE
Adding coverage reports

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -39,9 +39,11 @@ jobs:
     - name: Run tests
       run: poetry run pytest
 
-    - name: Run codecov
+    - name: Upload coverage reports to Codecov
       if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9)
       uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   docs_build:
     needs: qa

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The `pyrealm` package
 
+[![codecov](https://codecov.io/gh/ImperialCollegeLondon/pyrealm/branch/develop/graph/badge.svg)](https://codecov.io/gh/ImperialCollegeLondon/pyrealm)
+
 The `pyrealm` package provides a toolbox implementing some key models for estimating
 plant productivity, growth and demography in Python 3. The outputs of different models
 can be then easily fed into other models within `pyrealm` to allow productivity


### PR DESCRIPTION
This PR:

* Hopefully enables the code coverage comments on pull requests
* Adds a codecov badge to the README

Closes #62

From the CodeCov docs, it isn't clear that this starts doing anything until it is in `develop`, when it establishes a baseline to compare PRs to. So bit of a gamble on whether this works!