### PR TITLE
Added coverage report output step to GA pytest step

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -37,7 +37,7 @@ jobs:
       run: poetry install
 
     - name: Run tests
-      run: poetry run pytest
+      run: poetry run pytest --cov-report xml
 
     - name: Upload coverage reports to Codecov
       if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9)


### PR DESCRIPTION
I've reopened the #62 branch to add another fix to try and get coverage building.

* The `setup.cfg` makes `pytest` build HTML coverage reports (`--cov-report=html:reports/coverage`) but CodeCov requires a machine ingestable format. 
* This PR adds `--cov-report=xml` to the `pytest` action in GA, hopefully giving the `codecov` action something to upload.