### PR TITLE
Updated README and code of conduct.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include
+relevant motivation and context. List any dependencies that are required for this
+change.
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Optimization (back-end change that speeds up the code)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+
+## Key checklist
+
+- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
+- [ ] All tests pass: `$ poetry run pytest`
+
+## Further checks
+
+- [ ] Code is commented, particularly in hard-to-understand areas
+- [ ] Tests added that prove fix is effective or that feature works

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # The `pyrealm` package
 
 [![codecov](https://codecov.io/gh/ImperialCollegeLondon/pyrealm/branch/develop/graph/badge.svg)](https://codecov.io/gh/ImperialCollegeLondon/pyrealm)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8366847.svg)](https://doi.org/10.5281/zenodo.8366847)
+[![Test and build](https://github.com/ImperialCollegeLondon/pyrealm/actions/workflows/pyrealm_ci.yaml/badge.svg?branch=develop)](https://github.com/ImperialCollegeLondon/pyrealm/actions/workflows/pyrealm_ci.yaml)
 
 The `pyrealm` package provides a toolbox implementing some key models for estimating
 plant productivity, growth and demography in Python 3. The outputs of different models
@@ -25,8 +27,10 @@ roadmap along with the a feature set to aim for in version 1.0.0.
 
 ## Using `pyrealm`
 
-The `pyrealm` package requires Python 3.9 or greater and can be installed from
-[PyPi](https://pypi.org/project/pyrealm/):
+The `pyrealm` package requires Python 3.9 or greater. We make released versions
+available via [PyPi](https://pypi.org/project/pyrealm/) and also generate DOIs for each
+release via [Zenodo](https://doi.org/10.5281/zenodo.8366847). You can install the most
+recent release using `pip`:
 
 ```sh
 pip install pyrealm
@@ -77,10 +81,17 @@ Jupyter notebooks and how to use `pyrealm` with large datasets loaded using
 [`numpy`](https://numpy.org/) or [`xarray`](https://docs.xarray.dev/en/stable/) with
 `pyrealm` classes and functions.
 
+## Citing `pyrealm`
+
+The `pyrealm` repository can be cited following the information in the [citation
+file](./CITATION.cff). If you are using `pyrealm` in research, it is better to cite the
+DOI of the specific release from [Zenodo](https://doi.org/10.5281/zenodo.8366847).
+
 ## Developing `pyrealm`
 
 If you are interested in contributing to the development of `pyrealm`, please read the
-[guide for contributors](./CONTRIBUTING.md).
+[guide for contributors](./CONTRIBUTING.md). Please do also read the [code of
+conduct](./CODE_OF_CONDUCT.md) for contributing to this project.
 
 ## Support and funding
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",
-    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Development Status :: 4 - Beta",
 ]
 license = "MIT"
 packages = [


### PR DESCRIPTION
This PR:

* Adds a code of conduct to the repo.
* Updates README to cover some parts of the ICCS ReadMe template and link to the remaining information.
* Updates the project classifiers in `pyproject.toml`
* Adds a PR template.

I'm deliberately keeping the README relatively small and linking out to other documents (contributor guide and code of conduct).

Closes #94 