### PR TITLE
Updating the information on generating profiling call graph

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,10 +188,13 @@ poetry run pytest
 
 #### Using 'pytest-profiling'
 
-[Pytest-profiling](https://pypi.org/project/pytest-profiling/) is a plugin to pytest that
-enables profiling of tests. It can be used to generate a call graph and to determine the
-number of hits and total time spent in each function or method. Dedicated profiling tests
-have been created for PyRealm. Please see the relevant testing directory.
+[Pytest-profiling](https://pypi.org/project/pytest-profiling/) is a plugin to pytest
+that enables profiling of tests. It can be used to generate a call graph and to
+determine the number of hits and total time spent in each function or method.
+[Graphviz](https://pypi.org/project/graphviz/) is a package that uses `dot` command to
+facilitate the rendering of the call graph and a manual install of graphviz is required
+depending on the os. Dedicated profiling tests have been created for PyRealm.
+Please see the relevant testing directory.
 
 ```bash
 poetry run pytest <test_path> --profile
@@ -203,7 +206,7 @@ to generate a report. You can run
 poetry run pytest <test_path> --profile-svg
 ```
 
-to generate a call graph.
+to generate a call graph. The graph is stored with the name `combined.svg`.
 
 #### Using 'pytest-coverage'
 
@@ -214,8 +217,8 @@ coverage reports. You can run
 poetry run pytest --cov=<test_path>
 ```
 
-to perform coverage analysis. This can be used to determine if your contribution is adequately
-tested.
+to perform coverage analysis. The report is stored with the name `index.html`.
+It can be used to determine if your contribution is adequately tested.
 
 #### Using `doctest`
 


### PR DESCRIPTION
# Description

 CONTRIBUTING.md has been updated. Information on installing the graphviz software package for successful rendering of the profiling call graph has been added. The information may help developers who are able to generate an .svg file but are not able to render the graph. Also highlighted the name of the coverage report file `index.html` to make it easy to locate in the reports folder (the folder contains many other html files).

Fixes #145, 

## Type of change

- [x] Documentation
## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
