### PR TITLE
hotfix test_evap.py

### DIFF
--- a/tests/regression/splash/test_evap.py
+++ b/tests/regression/splash/test_evap.py
@@ -181,4 +181,4 @@ def test_evap_array_grid(splash_core_constants, grid_benchmarks, expected_attr):
     # been created in the original implementation, the whole time sequence can be passed
     # in as a single array and calculated without daily iteration
     aet = evap.estimate_aet(wn=expected["wn"].data, day_idx=None)
-    np.allclose(aet, expected["aet_d"], equal_nan=True)
+    assert np.allclose(aet, expected["aet_d"], equal_nan=True)


### PR DESCRIPTION
* Fixes a small error: `assert` is absent for checking `np.allclose(...)`.

@davidorme edits:

* Also fixes an error in the test input: AET needs to be calculated using the soil moisture estimate from the previous day. Including that offset correctly duplicates the expected outputs exactly.
* Fixes #173 