### PR TITLE
Fixing missing attribute docstrings in `core.calendar`

### DIFF
--- a/pyrealm/core/calendar.py
+++ b/pyrealm/core/calendar.py
@@ -61,7 +61,7 @@ class Calendar(Sized):
         >>> days=np.arange(
         ...     np.datetime64("2000-01-01"),
         ...     np.datetime64("2002-01-01"),
-        ...     np.timedelta64(1, "D)
+        ...     np.timedelta64(1, "D")
         ... )
         >>> cal = Calendar(days)
         >>> cal


### PR DESCRIPTION
# Description

This PR:

* Adds attribute docstrings to `Calendar` and `CalendarDay`
* Updates the docstrings throughout the module.
* Adds a custom and more compact `__repr__` for both dataclasses.
Fixes #164

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
