### PR TITLE
New subdaily pmodel implementation

### DIFF
--- a/docs/source/users/pmodel/subdaily_details/worked_example_new.md
+++ b/docs/source/users/pmodel/subdaily_details/worked_example_new.md
@@ -1,0 +1,233 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.1
+kernelspec:
+  display_name: pyrealm_python3
+  language: python
+  name: pyrealm_python3
+---
+
+# Draft implementation of general Subdaily model
+
+```{code-cell}
+from importlib import resources
+
+import xarray
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize
+import matplotlib.cm as cm
+import matplotlib.dates as mdates
+
+from pyrealm.pmodel import PModel, FastSlowPModel, PModelEnvironment, FastSlowScaler
+from pyrealm.pmodel.new_subdaily import SubdailyPModel
+
+from pyrealm.core.hygro import convert_sh_to_vpd
+```
+
+This notebook demonstrates a new implementation of the subdaily P Model.
+The current implementation (`pmodel.FastSlowPModel`) is a conversion of
+Giulia's original R code used for the JULES paper, although it extends that
+code to add slow acclimation of the `xi` parameter. The equations in that
+implementation are hard-coded to the Prentice et al (2014) equations for the
+C3 pathway.
+
+This version:
+
+1) Takes an existing P Model object fitted with _any_ of the existing calculation
+   methods for optimal `chi`. This includes the `prentice14` model but also the
+   existing `c4` and `c4_no_gamma`.
+2) The optimal chi calculations now have the option to assert the `xi` values to
+   be used. In the normal P Model, the expected `xi` is used, but now we can also
+   take the same forcing variables and recalculate with lagged `xi`.
+
+So the new implementation takes a P Model, calculates the daily optimal values
+during the acclimation window (as before), applies a lag (as before), but can
+now use the existing `pyrealm` optimal `chi` mechanism to estimate `chi`, `ci`,
+`mc` and `mj` using lagged `xi`. The lagged `vcmax` and `jmax` are calculated
+using the same `jmax` limitation scheme as the original model.
+
+Note that this _can_ also be used with the experimental optimal chi methods:
+Aliénor's soil moisture approaches and Rodolfo's rootzone stress. This makes
+intuitive sense - the plant acclimates to water stress too - but I don't know
+if this is the right way to apply this!
+
+The test data use some UK WFDE data for three sites in order to compare predictions
+over a time series.
+
+```{code-cell}
+# Loading the example dataset:
+dpath = (
+    resources.files("pyrealm_build_data.uk_data") / "UK_WFDE5_FAPAR_2018_JuneJuly.nc"
+)
+ds = xarray.load_dataset(dpath)
+
+datetimes = ds["time"].to_numpy()
+
+# Define three sites for showing time series
+sites = xarray.Dataset(
+    data_vars=dict(
+        lat=(["stid"], [50.73, 53.93, 58.03]), lon=(["stid"], [-3.52, -0.79, -4.41])
+    ),
+    coords=dict(stid=(["Exeter", "Pocklington", "Lairg"])),
+)
+```
+
+The WFDE data need some conversion for use in the PModel, along with the definition of
+the atmospheric CO2 concentration.
+
+```{code-cell}
+# Variable set up
+# Air temperature in °C from Tair in Kelvin
+tc = (ds["Tair"] - 273.15).to_numpy()
+# Atmospheric pressure in Pascals
+patm = ds["PSurf"].to_numpy()
+# Convert specific huidity to VPD and remove negative values
+vpd = convert_sh_to_vpd(sh=ds["Qair"].to_numpy(), ta=tc, patm=patm / 1000) * 1000
+vpd = np.clip(vpd, 0, np.inf)
+# Extract fAPAR (unitless)
+fapar = ds["fAPAR"].to_numpy()
+# Convert SW downwelling radiation from W/m^2 to PPFD µmole/m2/s1
+ppfd = ds["SWdown"].to_numpy() * 2.04
+# Define atmospheric CO2 concentration (ppm)
+co2 = np.ones_like(tc) * 400
+```
+
+The code below then calculates the photosynthetic environment.
+
+```{code-cell}
+# Generate and check the PModelEnvironment
+pm_env = PModelEnvironment(tc=tc, patm=patm, vpd=vpd, co2=co2)
+pm_env.summarize()
+```
+
+## Instantaneous C3 and C4 P Models
+
+The standard implementation of the P Model used below assumes that plants can
+instantaneously adopt optimal behaviour.
+
+```{code-cell}
+# Standard PModels
+pmodC3 = PModel(env=pm_env, kphio=1 / 8, method_optchi="prentice14")
+pmodC3.estimate_productivity(fapar=fapar, ppfd=ppfd)
+pmodC3.summarize()
+```
+
+```{code-cell}
+pmodC4 = PModel(env=pm_env, kphio=1 / 8, method_optchi="c4_no_gamma")
+pmodC4.estimate_productivity(fapar=fapar, ppfd=ppfd)
+pmodC4.summarize()
+```
+
+## Subdaily P Model
+
+The code below then refits these models, with slow responses in $\xi$, $V_{cmax25}$ and
+$J_{max25}$. The new implementation is
+
+```{code-cell}
+# Set the acclimation window to an hour either side of noon
+fsscaler = FastSlowScaler(datetimes)
+fsscaler.set_window(
+    window_center=np.timedelta64(12, "h"),
+    half_width=np.timedelta64(1, "h"),
+)
+
+# Fit C3 and C4 with the new implementation
+subdailyC3 = SubdailyPModel(
+    pmodel=pmodC3, fs_scaler=fsscaler, alpha=1 / 15, handle_nan=True
+)
+subdailyC4 = SubdailyPModel(
+    pmodel=pmodC4, fs_scaler=fsscaler, alpha=1 / 15, handle_nan=True
+)
+
+# Fit C3 using the original implementation
+fs_pmod = FastSlowPModel(
+    env=pm_env,
+    fs_scaler=fsscaler,
+    handle_nan=True,
+    fapar=fapar,
+    ppfd=ppfd,
+    alpha=1 / 15,
+)
+```
+
+Reassuringly, the two subdaily C3 models predict equal GPP, except for trivial
+precision differences.
+
+```{code-cell}
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10, 4))
+
+ax1.scatter(fs_pmod.gpp.flatten(), subdailyC3.gpp.flatten())
+ax1.set_xlabel("GPP from original implementation")
+ax1.set_ylabel("GPP from new implementation")
+
+ax2.hist((fs_pmod.gpp.flatten() - subdailyC3.gpp.flatten()) / subdailyC3.gpp.flatten())
+ax2.set_xlabel("Percentage difference in GPP")
+```
+
+## Time series predictions
+
+The code below then extracts the time series for the two months from the three sites
+shown above and plots the instantaneous predictions against predictions including slow
+photosynthetic responses.
+
+```{code-cell}
+# Store the predictions in the xarray Dataset to use indexing
+ds["GPP_pmodC3"] = (ds["Tair"].dims, pmodC3.gpp)
+ds["GPP_subdailyC3"] = (ds["Tair"].dims, subdailyC3.gpp)
+ds["GPP_pmodC4"] = (ds["Tair"].dims, pmodC4.gpp)
+ds["GPP_subdailyC4"] = (ds["Tair"].dims, subdailyC4.gpp)
+
+# Get three sites to show time series for locations
+site_ds = ds.sel(sites, method="nearest")
+
+# Set up subplots
+fig, axes = plt.subplots(3, 2, figsize=(10, 8), sharey=True)
+
+# Plot the time series for the two approaches for each site
+for (ax1, ax2), st in zip(axes, sites["stid"].values):
+
+    ax1.plot(
+        datetimes,
+        site_ds["GPP_pmodC3"].sel(stid=st),
+        label="Instantaneous",
+        color="0.4",
+    )
+    ax1.plot(
+        datetimes,
+        site_ds["GPP_subdailyC3"].sel(stid=st),
+        label="Subdaily",
+        color="red",
+        alpha=0.7,
+    )
+    ax1.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
+    ax1.text(0.02, 0.90, st + " - C3", transform=ax1.transAxes)
+
+    ax2.plot(
+        datetimes,
+        site_ds["GPP_pmodC4"].sel(stid=st),
+        label="Instantaneous",
+        color="0.4",
+    )
+    ax2.plot(
+        datetimes,
+        site_ds["GPP_subdailyC4"].sel(stid=st),
+        label="Subdaily",
+        color="red",
+        alpha=0.7,
+    )
+    ax2.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
+    ax2.text(0.02, 0.90, st + " - C4", transform=ax2.transAxes)
+
+axes[0][0].legend(loc="lower center", bbox_to_anchor=[0.5, 1], ncols=2, frameon=False)
+plt.tight_layout()
+```
+
+```{code-cell}
+
+```

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -111,6 +111,12 @@ class PModelConst(ConstantsClass):
     kattge_knorr_Hd: float = 200000
     """Deactivation energy (:math:`H_d`, 200000, J/mol)"""
 
+    # Subdaily activatation energy
+    subdaily_vcmax25_ha: float = 65330
+    """Activation energy for vcmax25 (:math:`H_a`, 65330, J/mol)"""
+    subdaily_jmax25_ha: float = 43900
+    """Activation energy for jmax25 (:math:`H_a`, 43900, J/mol)"""
+
     # Kphio:
     # - note that kphio_C4 has been updated to account for an unintended double
     #   8 fold downscaling to account for the fraction of light reaching PS2.

--- a/pyrealm/core/water.py
+++ b/pyrealm/core/water.py
@@ -2,7 +2,6 @@
 density and viscosity of water given the air temperature and atmospheric pressure.
 """  # noqa D210, D415
 
-
 import numpy as np
 from numpy.typing import NDArray
 

--- a/pyrealm/pmodel/new_subdaily.py
+++ b/pyrealm/pmodel/new_subdaily.py
@@ -240,3 +240,28 @@ class SubdailyPModel:
             * self.env.core_const.k_c_molmass
         )
         """Estimated subdaily GPP."""
+
+
+def pmodel_to_subdaily(
+    pmodel: PModel,
+    fs_scaler: FastSlowScaler,
+    alpha: float = 1 / 15,
+    handle_nan: bool = False,
+    fill_kind: str = "previous",
+) -> SubdailyPModel:
+    """Draft function to convert standard P Model to subdaily P Model."""
+    # Check that productivity has been estimated
+
+    return SubdailyPModel(
+        env=pmodel.env,
+        fs_scaler=fs_scaler,
+        fapar=pmodel.fapar,
+        ppfd=pmodel.ppfd,
+        kphio=pmodel.init_kphio,
+        do_ftemp_kphio=pmodel.do_ftemp_kphio,
+        method_optchi=pmodel.method_optchi,
+        method_jmaxlim=pmodel.method_jmaxlim,
+        alpha=alpha,
+        handle_nan=handle_nan,
+        fill_kind=fill_kind,
+    )

--- a/pyrealm/pmodel/new_subdaily.py
+++ b/pyrealm/pmodel/new_subdaily.py
@@ -107,9 +107,11 @@ class SubdailyPModel:
         self.env = pmodel.env
 
         # 1) Generate a PModelEnvironment containing the average conditions within the
-        #    daily acclimation window, including any of the optional variables provided.
+        #    daily acclimation window, including any optional variables required by the
+        #    optimal chi calculations used in the model.
+        daily_environment_vars = ["tc", "co2", "patm", "vpd"] + pmodel.optchi.requires
         daily_environment: dict[str, NDArray] = {}
-        for env_var_name in ("tc", "co2", "patm", "vpd", "theta", "rootzonestress"):
+        for env_var_name in daily_environment_vars:
             env_var = getattr(self.env, env_var_name)
             if env_var is not None:
                 daily_environment[env_var_name] = fs_scaler.get_daily_means(env_var)

--- a/pyrealm/pmodel/new_subdaily.py
+++ b/pyrealm/pmodel/new_subdaily.py
@@ -70,7 +70,7 @@ class SubdailyPModel:
         ppfd: The PPDF for each observation.
         alpha: The :math:`\alpha` weight.
         handle_nan: Should the :func:`~pyrealm.pmodel.subdaily.memory_effect` function
-          be allowe to handle missing values.
+          be allowed to handle missing values.
         kphio: The quantum yield efficiency of photosynthesis (:math:`\phi_0`, -).
         fill_kind: The approach used to fill daily realised values to the subdaily
           timescale, currently one of 'previous' or 'linear'.
@@ -242,14 +242,32 @@ class SubdailyPModel:
         """Estimated subdaily GPP."""
 
 
-def pmodel_to_subdaily(
+def convert_pmodel_to_subdaily(
     pmodel: PModel,
     fs_scaler: FastSlowScaler,
     alpha: float = 1 / 15,
     handle_nan: bool = False,
     fill_kind: str = "previous",
 ) -> SubdailyPModel:
-    """Draft function to convert standard P Model to subdaily P Model."""
+    r"""Convert a standard P Model to a subdaily P Model.
+
+    This function takes an existing :class:`~pyrealm.pmodel.pmodel.PModel` instance and
+    converts it to a :class:`~pyrealm.pmodel.new_subdaily.SubfdailyPModel` instance
+    using provided settings. The
+    :meth:`~pyrealm.pmodel.pmodel.PModel.estimate_productivity` method must have been
+    called on the :class:`~pyrealm.pmodel.pmodel.PModel` instance in order to provide
+    PPFD and FAPAR to the subdaily model
+
+    Args:
+        pmodel: An existing standard PModel instance.
+        fs_scaler: A FastSlowScalar instance giving the acclimation window for the
+            subdaily model.
+        alpha: The :math:`\alpha` weight.
+        handle_nan: Should the :func:`~pyrealm.pmodel.subdaily.memory_effect` function
+          be allowed to handle missing values.
+        fill_kind: The approach used to fill daily realised values to the subdaily
+          timescale, currently one of 'previous' or 'linear'.
+    """
     # Check that productivity has been estimated
 
     return SubdailyPModel(

--- a/pyrealm/pmodel/new_subdaily.py
+++ b/pyrealm/pmodel/new_subdaily.py
@@ -1,0 +1,223 @@
+r"""The :mod:`~pyrealm.pmodel.subdaily` module provides extensions to the P Model that
+incorporate modelling of the fast and slow responses of photosynthesis to changing
+conditions.
+"""  # noqa: D205, D415
+from warnings import warn
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pyrealm import ExperimentalFeatureWarning
+from pyrealm.pmodel import (
+    FastSlowScaler,
+    PModel,
+    PModelEnvironment,
+    calc_ftemp_arrh,
+    memory_effect,
+)
+from pyrealm.pmodel.optimal_chi import OPTIMAL_CHI_CLASS_REGISTRY
+
+
+class SubdailyPModel:
+    r"""Fit a P Model incorporating fast and slow photosynthetic responses.
+
+    The :class:`~pyrealm.pmodel.pmodel.PModel` implementation of the P Model assumes
+    that plants instantaneously adopt optimal behaviour, which is reasonable where the
+    data represents average conditions over longer timescales and the plants can be
+    assumed to have acclimated to optimal behaviour. Over shorter timescales, this
+    assumption is unwarranted and photosynthetic slow responses need to be included.
+    This class implements the weighted-average approach of {cite:t}`mengoli:2022a`, but
+    is extended to include the slow response of :math:`\xi` in addition to
+    :math:`V_{cmax25}` and :math:`J_{max25}`.
+
+    The first dimension of the data arrays use to create the
+    :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` instance must
+    represent
+    the time
+    axis of the observations. The actual datetimes of those observations must then be
+    used to initialiase a :class:`~pyrealm.pmodel.fast_slow_scaler.FastSlowScaler`
+    instance, and one of the ``set_`` methods of that class must be used to define an
+    acclimation window.
+
+    The workflow of the model is then:
+
+    * The daily acclimation window set in the
+      :class:`~pyrealm.pmodel.fast_slow_scaler.FastSlowScaler` instance is used to
+      calculate daily average values for forcing variables from within the acclimation
+      window.
+    * A standard P Model is then run on those daily forcing values to generate predicted
+      states for photosynthetic parameters that give rise to optimal productivity.
+    * The :meth:`~pyrealm.pmodel.subdaily.memory_effect` function is then used to
+      calculate realised slowly responding values for :math:`\xi`, :math:`V_{cmax25}`
+      and :math:`J_{max25}`, given a weight :math:`\alpha \in [0,1]` that sets the speed
+      of acclimation. The ``handle_nan`` argument is passed to this function to set
+      whether missing values in the optimal predictions are permitted and handled.
+    * The realised values are then filled back onto the original subdaily timescale,
+      with :math:`V_{cmax}` and :math:`J_{max}` then being calculated from the slowly
+      responding :math:`V_{cmax25}` and :math:`J_{max25}` and the actual subdaily
+      temperature observations and :math:`c_i` calculated using realised values of
+      :math:`\xi` but subdaily values in the other parameters.
+    * Predictions of GPP are then made as in the standard P Model.
+
+    Args:
+        env: An instance of
+          :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`
+        fs_scaler: An instance of
+          :class:`~pyrealm.pmodel.fast_slow_scaler.FastSlowScaler`.
+        fapar: The :math:`f_{APAR}` for each observation.
+        ppfd: The PPDF for each observation.
+        alpha: The :math:`\alpha` weight.
+        handle_nan: Should the :func:`~pyrealm.pmodel.subdaily.memory_effect` function
+          be allowe to handle missing values.
+        kphio: The quantum yield efficiency of photosynthesis (:math:`\phi_0`, -).
+        fill_kind: The approach used to fill daily realised values to the subdaily
+          timescale, currently one of 'previous' or 'linear'.
+    """
+
+    def __init__(
+        self,
+        pmodel: PModel,
+        fs_scaler: FastSlowScaler,
+        alpha: float = 1 / 15,
+        handle_nan: bool = False,
+        fill_kind: str = "previous",
+    ) -> None:
+        # Warn about the API
+        warn(
+            "This is a draft implementation and the API and calculations may change",
+            ExperimentalFeatureWarning,
+        )
+
+        # Check that the length of the fast slow scaler is congruent with the
+        # first axis of the photosynthetic environment
+        n_datetimes = fs_scaler.datetimes.shape[0]
+        n_env_first_axis = pmodel.env.tc.shape[0]
+
+        if n_datetimes != n_env_first_axis:
+            raise ValueError("env and fs_scaler do not have congruent dimensions")
+
+        # Has a set method been run on the fast slow scaler
+        if not hasattr(fs_scaler, "include"):
+            raise ValueError("The daily sampling window has not been set on fs_scaler")
+
+        # Check that estimate_productivity has been run on the model
+        if not hasattr(pmodel, "_gpp"):
+            raise ValueError("The subdaily model requires estimate_productivity")
+
+        self.env = pmodel.env
+
+        # 1) Generate a PModelEnvironment containing the average conditions within the
+        #    daily acclimation window, including any of the optional variables provided.
+        daily_environment: dict[str, NDArray] = {}
+        for env_var_name in ("tc", "co2", "patm", "vpd", "theta", "rootzonestress"):
+            env_var = getattr(self.env, env_var_name)
+            if env_var is not None:
+                daily_environment[env_var_name] = fs_scaler.get_daily_means(env_var)
+
+        pmodel_env_acclim = PModelEnvironment(
+            **daily_environment,
+            pmodel_const=self.env.pmodel_const,
+            core_const=self.env.core_const,
+        )
+
+        # 2) Fit a PModel to those environmental conditions, using the supplied settings
+        #    for the original model.
+        self.pmodel_acclim: PModel = PModel(
+            pmodel_env_acclim,
+            kphio=pmodel.init_kphio,
+            do_ftemp_kphio=pmodel.do_ftemp_kphio,
+            method_optchi=pmodel.method_optchi,
+            method_jmaxlim=pmodel.method_jmaxlim,
+        )
+        r"""P Model predictions for the daily acclimation conditions.
+
+        A :class:`~pyrealm.pmodel.pmodel.PModel` instance providing the predictions of
+        the P Model for the daily acclimation conditions set for the FastSlowPModel. The
+        model is used to obtain predictions of the instantaneously optimal estimates of
+        :math:`V_{cmax}`, :math:`J_{max}` and :math:`\xi` during the acclimation window.
+        These are then used to estimate realised values of those parameters given slow
+        responses to acclimation.
+        """
+
+        # 3) Estimate productivity to calculate jmax and vcmax
+        self.ppfd_acclim = fs_scaler.get_daily_means(pmodel.ppfd)
+        self.fapar_acclim = fs_scaler.get_daily_means(pmodel.fapar)
+
+        self.pmodel_acclim.estimate_productivity(
+            fapar=self.fapar_acclim, ppfd=self.ppfd_acclim
+        )
+
+        # 4) Calculate the optimal jmax and vcmax at 25°C
+        # TODO - Are these any of the existing values in the constants?
+        ha_vcmax25 = 65330
+        ha_jmax25 = 43900
+
+        tk_acclim = pmodel_env_acclim.tc + self.env.core_const.k_CtoK
+        self.vcmax25_opt = self.pmodel_acclim.vcmax * (
+            1 / calc_ftemp_arrh(tk_acclim, ha_vcmax25)
+        )
+        self.jmax25_opt = self.pmodel_acclim.jmax * (
+            1 / calc_ftemp_arrh(tk_acclim, ha_jmax25)
+        )
+
+        # 5) Calculate the realised daily values from the instantaneous optimal values
+        self.xi_real: NDArray = memory_effect(
+            self.pmodel_acclim.optchi.xi, alpha=alpha, handle_nan=handle_nan
+        )
+        r"""Realised daily slow responses in :math:`\xi`"""
+        self.vcmax25_real: NDArray = memory_effect(
+            self.vcmax25_opt, alpha=alpha, handle_nan=handle_nan
+        )
+        r"""Realised daily slow responses in :math:`V_{cmax25}`"""
+        self.jmax25_real: NDArray = memory_effect(
+            self.jmax25_opt, alpha=alpha, handle_nan=handle_nan
+        )
+        r"""Realised daily slow responses in :math:`J_{max25}`"""
+
+        # 6) Fill the realised xi, jmax25 and vcmax25 from daily values back to the
+        # subdaily timescale.
+        self.subdaily_vcmax25 = fs_scaler.fill_daily_to_subdaily(self.vcmax25_real)
+        self.subdaily_jmax25 = fs_scaler.fill_daily_to_subdaily(self.jmax25_real)
+        self.subdaily_xi = fs_scaler.fill_daily_to_subdaily(self.xi_real)
+
+        # 7) Adjust subdaily jmax25 and vcmax25 back toto jmax and vcmax given the
+        #    actual subdaily temperatures.
+        subdaily_tk = self.env.tc + self.env.core_const.k_CtoK
+        self.subdaily_vcmax: NDArray = self.subdaily_vcmax25 * calc_ftemp_arrh(
+            tk=subdaily_tk, ha=ha_vcmax25
+        )
+        """Estimated subdaily :math:`V_{cmax}`."""
+
+        self.subdaily_jmax: NDArray = self.subdaily_jmax25 * calc_ftemp_arrh(
+            tk=subdaily_tk, ha=ha_jmax25
+        )
+        """Estimated subdaily :math:`J_{max}`."""
+
+        # 8) Recalculate chi using the OptimalChi class from the provided method.
+        optimal_chi_class = OPTIMAL_CHI_CLASS_REGISTRY[pmodel.method_optchi]
+        self.optimal_chi = optimal_chi_class(
+            env=self.env, pmodel_const=pmodel.pmodel_const
+        )
+        self.optimal_chi.estimate_chi(xi_values=self.subdaily_xi)
+
+        """Estimated subdaily :math:`c_i`."""
+
+        # Calculate Ac, J and Aj at subdaily scale to calculate assimilation
+        self.subdaily_Ac: NDArray = self.subdaily_vcmax * self.optimal_chi.mc
+        """Estimated subdaily :math:`A_c`."""
+
+        iabs = pmodel.fapar * pmodel.ppfd
+
+        subdaily_J = (4 * pmodel.kphio * iabs) / np.sqrt(
+            1 + ((4 * pmodel.kphio * iabs) / self.subdaily_jmax) ** 2
+        )
+
+        self.subdaily_Aj: NDArray = (subdaily_J / 4) * self.optimal_chi.mj
+        """Estimated subdaily :math:`A_j`."""
+
+        # Calculate GPP and convert from mol to gC
+        self.gpp: NDArray = (
+            np.minimum(self.subdaily_Aj, self.subdaily_Ac)
+            * self.env.core_const.k_c_molmass
+        )
+        """Estimated subdaily GPP."""

--- a/pyrealm/pmodel/new_subdaily.py
+++ b/pyrealm/pmodel/new_subdaily.py
@@ -2,6 +2,7 @@ r"""The :mod:`~pyrealm.pmodel.subdaily` module provides extensions to the P Mode
 incorporate modelling of the fast and slow responses of photosynthesis to changing
 conditions.
 """  # noqa: D205, D415
+
 from warnings import warn
 
 import numpy as np
@@ -150,16 +151,12 @@ class SubdailyPModel:
         )
 
         # 4) Calculate the optimal jmax and vcmax at 25°C
-        # TODO - Are these any of the existing values in the constants?
-        ha_vcmax25 = 65330
-        ha_jmax25 = 43900
-
         tk_acclim = pmodel_env_acclim.tc + self.env.core_const.k_CtoK
         self.vcmax25_opt = self.pmodel_acclim.vcmax * (
-            1 / calc_ftemp_arrh(tk_acclim, ha_vcmax25)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_vcmax25_ha)
         )
         self.jmax25_opt = self.pmodel_acclim.jmax * (
-            1 / calc_ftemp_arrh(tk_acclim, ha_jmax25)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_jmax25_ha)
         )
 
         # 5) Calculate the realised daily values from the instantaneous optimal values
@@ -186,12 +183,12 @@ class SubdailyPModel:
         #    actual subdaily temperatures.
         subdaily_tk = self.env.tc + self.env.core_const.k_CtoK
         self.subdaily_vcmax: NDArray = self.subdaily_vcmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=ha_vcmax25
+            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_vcmax25_ha
         )
         """Estimated subdaily :math:`V_{cmax}`."""
 
         self.subdaily_jmax: NDArray = self.subdaily_jmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=ha_jmax25
+            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_jmax25_ha
         )
         """Estimated subdaily :math:`J_{max}`."""
 

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -5,7 +5,7 @@ the following pmodel core class:
     Applies the PModel to locations.
 """  # noqa D210, D415
 
-from typing import Optional, Union
+from typing import Optional
 from warnings import warn
 
 import numpy as np
@@ -295,6 +295,8 @@ class PModel:
         self._jmax: NDArray
         self._gpp: NDArray
         self._gs: NDArray
+        self._ppfd: NDArray
+        self._fapar: NDArray
 
     def _check_estimated(self, varname: str) -> None:
         """Raise error when accessing unpopulated parameters.
@@ -342,8 +344,20 @@ class PModel:
         self._check_estimated("gs")
         return self._gs
 
+    @property
+    def ppfd(self) -> NDArray:
+        """Stomatal conductance (µmol m-2 s-1)."""
+        self._check_estimated("gs")
+        return self._ppfd
+
+    @property
+    def fapar(self) -> NDArray:
+        """Stomatal conductance (µmol m-2 s-1)."""
+        self._check_estimated("gs")
+        return self._fapar
+
     def estimate_productivity(
-        self, fapar: Union[float, np.ndarray] = 1, ppfd: Union[float, np.ndarray] = 1
+        self, fapar: np.ndarray = np.array([1]), ppfd: np.ndarray = np.array([1])
     ) -> None:
         r"""Estimate productivity of P Model from absorbed irradiance.
 
@@ -373,6 +387,11 @@ class PModel:
 
         # Check input shapes against each other and an existing calculated value
         _ = check_input_shapes(ppfd, fapar, self.lue)
+
+        # Store the input ppfd and fapar - this is primarily so that they can be reused
+        # by the subdaily model
+        self._fapar = fapar
+        self._ppfd = ppfd
 
         # Calculate Iabs
         iabs = fapar * ppfd

--- a/pyrealm/pmodel/subdaily.py
+++ b/pyrealm/pmodel/subdaily.py
@@ -2,6 +2,7 @@ r"""The :mod:`~pyrealm.pmodel.subdaily` module provides extensions to the P Mode
 incorporate modelling of the fast and slow responses of photosynthesis to changing
 conditions.
 """  # noqa: D205, D415
+
 from typing import Optional
 from warnings import warn
 
@@ -244,16 +245,13 @@ class FastSlowPModel:
         )
 
         # Calculate the optimal jmax and vcmax at 25°C
-        # TODO - Are these any of the existing values in the constants?
-        ha_vcmax25 = 65330
-        ha_jmax25 = 43900
 
         tk_acclim = temp_acclim + self.env.core_const.k_CtoK
         self.vcmax25_opt = self.pmodel_acclim.vcmax * (
-            1 / calc_ftemp_arrh(tk_acclim, ha_vcmax25)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_vcmax25_ha)
         )
         self.jmax25_opt = self.pmodel_acclim.jmax * (
-            1 / calc_ftemp_arrh(tk_acclim, ha_jmax25)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_jmax25_ha)
         )
 
         # Calculate the realised values from the instantaneous optimal values
@@ -281,12 +279,12 @@ class FastSlowPModel:
         self.subdaily_xi = fs_scaler.fill_daily_to_subdaily(self.xi_real)
 
         self.subdaily_vcmax: NDArray = self.subdaily_vcmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=ha_vcmax25
+            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_vcmax25_ha
         )
         """Estimated subdaily :math:`V_{cmax}`."""
 
         self.subdaily_jmax: NDArray = self.subdaily_jmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=ha_jmax25
+            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_jmax25_ha
         )
         """Estimated subdaily :math:`J_{max}`."""
 
@@ -452,16 +450,12 @@ class FastSlowPModel_JAMES:
         )
 
         # Calculate the optimal jmax and vcmax at 25°C
-        # TODO - Are these any of the existing values in the constants?
-        ha_vcmax25 = 65330
-        ha_jmax25 = 43900
-
         tk_acclim = temp_acclim + self.env.core_const.k_CtoK
         self.vcmax25_opt = self.pmodel_acclim.vcmax * (
-            1 / calc_ftemp_arrh(tk_acclim, ha_vcmax25)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_vcmax25_ha)
         )
         self.jmax25_opt = self.pmodel_acclim.jmax * (
-            1 / calc_ftemp_arrh(tk_acclim, ha_jmax25)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_jmax25_ha)
         )
 
         # Calculate the realised values from the instantaneous optimal values
@@ -509,12 +503,12 @@ class FastSlowPModel_JAMES:
         )
 
         self.subdaily_vcmax: NDArray = self.subdaily_vcmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=ha_vcmax25
+            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_vcmax25_ha
         )
         """Estimated subdaily :math:`V_{cmax}`."""
 
         self.subdaily_jmax: NDArray = self.subdaily_jmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=ha_jmax25
+            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_jmax25_ha
         )
         """Estimated subdaily :math:`J_{max}`."""
 

--- a/tests/unit/pmodel/test_new_subdaily.py
+++ b/tests/unit/pmodel/test_new_subdaily.py
@@ -1,4 +1,5 @@
 """Tests the implementation of the FastSlowModel against the reference benchmark."""
+
 from importlib import resources
 
 import numpy as np
@@ -132,7 +133,9 @@ def test_FSPModel_corr(be_vie_data_components):
 
     # Run as a subdaily model
     fs_pmodel = SubdailyPModel(
-        pmodel=pmodel,
+        env=env,
+        ppfd=ppfd,
+        fapar=fapar,
         fs_scaler=fsscaler,
         handle_nan=True,
     )
@@ -157,7 +160,7 @@ def test_FSPModel_dimensionality(be_vie_data, ndims):
     dimensions to check the results scale as expected.
     """
 
-    from pyrealm.pmodel import FastSlowScaler, PModel, PModelEnvironment
+    from pyrealm.pmodel import FastSlowScaler, PModelEnvironment
     from pyrealm.pmodel.new_subdaily import SubdailyPModel
 
     datetime = be_vie_data["time"].astype(np.datetime64)
@@ -188,15 +191,12 @@ def test_FSPModel_dimensionality(be_vie_data, ndims):
     fapar_vals = np.random.random(extra_dims)
     fapar_vals[0] = 1.0
 
-    pmodel = PModel(env, kphio=1 / 8)
-    pmodel.estimate_productivity(
-        fapar=fapar_vals * np.ones(array_dims).transpose(),
-        ppfd=np.ones(array_dims).transpose(),
-    )
     # Fast slow model
     fs_pmodel = SubdailyPModel(
-        pmodel=pmodel,
+        env=env,
         fs_scaler=fsscaler,
+        fapar=fapar_vals * np.ones(array_dims).transpose(),
+        ppfd=np.ones(array_dims).transpose(),
         handle_nan=True,
     )
 
@@ -215,14 +215,10 @@ def test_Subdaily_opt_chi_methods(be_vie_data_components, method_optchi):
     implementations of the OptimalChi ABC.
     """
 
-    from pyrealm.pmodel import FastSlowScaler, PModel
+    from pyrealm.pmodel import FastSlowScaler
     from pyrealm.pmodel.new_subdaily import SubdailyPModel
 
     env, ppfd, fapar, datetime, _ = be_vie_data_components
-
-    # Fit the standard P Model
-    pmodel = PModel(env=env, kphio=1 / 8, method_optchi=method_optchi)
-    pmodel.estimate_productivity(fapar=fapar, ppfd=ppfd)
 
     # Get the fast slow scaler and set window
     fsscaler = FastSlowScaler(datetime)
@@ -233,7 +229,9 @@ def test_Subdaily_opt_chi_methods(be_vie_data_components, method_optchi):
 
     # Run as a subdaily model and it should complete.
     _ = SubdailyPModel(
-        pmodel=pmodel,
+        env=env,
         fs_scaler=fsscaler,
+        fapar=fapar,
+        ppfd=ppfd,
         handle_nan=True,
     )

--- a/tests/unit/pmodel/test_new_subdaily.py
+++ b/tests/unit/pmodel/test_new_subdaily.py
@@ -1,0 +1,239 @@
+"""Tests the implementation of the FastSlowModel against the reference benchmark."""
+from importlib import resources
+
+import numpy as np
+import pytest
+
+from pyrealm.pmodel.optimal_chi import OPTIMAL_CHI_CLASS_REGISTRY
+
+
+@pytest.fixture(scope="module")
+def be_vie_data():
+    """Import the benchmark test data."""
+
+    # This feels like a hack but it isn't obvious how to reference the data files
+    # included in the source distribution from the package path.
+    data_path = (
+        resources.files("pyrealm_build_data.subdaily") / "subdaily_BE_Vie_2014.csv"
+    )
+
+    data = np.genfromtxt(
+        fname=data_path,
+        names=True,
+        delimiter=",",
+        dtype=None,
+        encoding="UTF8",
+        missing_values="NA",
+    )
+
+    return data
+
+
+@pytest.fixture(scope="module")
+def be_vie_data_components(be_vie_data):
+    """Convert the test data into a PModelEnv and arrays."""
+
+    from pyrealm.pmodel import PModelEnvironment
+
+    # Extract the key half hourly timestep variables
+    ppfd_subdaily = be_vie_data["ppfd"]
+    fapar_subdaily = be_vie_data["fapar"]
+    datetime_subdaily = be_vie_data["time"].astype(np.datetime64)
+    expected_gpp = be_vie_data["GPP_JAMES"]
+
+    # Create the environment including some randomly distributed water variables to test
+    # the methods that require those variables
+    rng = np.random.default_rng()
+    subdaily_env = PModelEnvironment(
+        tc=be_vie_data["ta"],
+        vpd=be_vie_data["vpd"],
+        co2=be_vie_data["co2"],
+        patm=be_vie_data["patm"],
+        theta=rng.uniform(low=0.7, high=1.0, size=be_vie_data["ppfd"].shape),
+        rootzonestress=rng.uniform(low=0.7, high=1.0, size=be_vie_data["ppfd"].shape),
+    )
+
+    return subdaily_env, ppfd_subdaily, fapar_subdaily, datetime_subdaily, expected_gpp
+
+
+def test_FSPModel_JAMES(be_vie_data_components):
+    """Test FastSlowPModel_JAMES.
+
+    This tests the legacy calculations from the Mengoli et al JAMES paper, using that
+    version of the weighted average calculations without acclimating xi.
+    """
+
+    from pyrealm.pmodel import FastSlowScaler
+    from pyrealm.pmodel.subdaily import FastSlowPModel_JAMES
+
+    env, ppfd, fapar, datetime, expected_gpp = be_vie_data_components
+
+    # Get the fast slow scaler and set window
+    fsscaler = FastSlowScaler(datetime)
+    fsscaler.set_window(
+        window_center=np.timedelta64(12, "h"),
+        half_width=np.timedelta64(30, "m"),
+    )
+
+    # Alternate scalar used to duplicate VPD settings in JAMES implementation
+    vpdscaler = FastSlowScaler(datetime)
+    vpdscaler.set_nearest(time=np.timedelta64(12, "h"))
+
+    # Fast slow model without acclimating xi with best fit adaptations to the original
+    # - VPD in daily optimum using different window
+    # - Jmax and Vcmax filling from midday not window end
+    fs_pmodel_james = FastSlowPModel_JAMES(
+        env=env,
+        fs_scaler=fsscaler,
+        handle_nan=True,
+        kphio=1 / 8,
+        fapar=fapar,
+        ppfd=ppfd,
+        vpd_scaler=vpdscaler,
+        fill_from=np.timedelta64(12, "h"),
+    )
+
+    valid = np.logical_not(
+        np.logical_or(np.isnan(expected_gpp), np.isnan(fs_pmodel_james.gpp))
+    )
+
+    # Test that non-NaN predictions are within 0.5% - slight differences in constants
+    # and rounding of outputs prevent a closer match between the implementations
+    assert np.allclose(
+        fs_pmodel_james.gpp[valid],
+        expected_gpp[valid] * env.core_const.k_c_molmass,
+        rtol=0.005,
+    )
+
+
+def test_FSPModel_corr(be_vie_data_components):
+    """Test FastSlowPModel.
+
+    This tests that the pyrealm implementation including acclimating xi at least
+    correlates well with the legacy calculations from the Mengoli et al JAMES paper
+    without acclimating xi.
+    """
+
+    from pyrealm.pmodel import FastSlowScaler, PModel
+    from pyrealm.pmodel.new_subdaily import SubdailyPModel
+
+    env, ppfd, fapar, datetime, expected_gpp = be_vie_data_components
+
+    # Fit the standard P Model
+    pmodel = PModel(env=env, kphio=1 / 8)
+    pmodel.estimate_productivity(fapar=fapar, ppfd=ppfd)
+
+    # Get the fast slow scaler and set window
+    fsscaler = FastSlowScaler(datetime)
+    fsscaler.set_window(
+        window_center=np.timedelta64(12, "h"),
+        half_width=np.timedelta64(30, "m"),
+    )
+
+    # Run as a subdaily model
+    fs_pmodel = SubdailyPModel(
+        pmodel=pmodel,
+        fs_scaler=fsscaler,
+        handle_nan=True,
+    )
+
+    valid = np.logical_not(
+        np.logical_or(np.isnan(expected_gpp), np.isnan(fs_pmodel.gpp))
+    )
+
+    # Test that non-NaN predictions correlate well and are approximately the same
+    gpp_in_micromols = fs_pmodel.gpp[valid] / env.core_const.k_c_molmass
+    assert np.allclose(gpp_in_micromols, expected_gpp[valid], rtol=0.2)
+    r_vals = np.corrcoef(gpp_in_micromols, expected_gpp[valid])
+    assert np.all(r_vals > 0.995)
+
+
+@pytest.mark.parametrize("ndims", [2, 3, 4])
+def test_FSPModel_dimensionality(be_vie_data, ndims):
+    """Tests that the FastSlowPModel handles dimensions correctly.
+
+    This broadcasts the BE-Vie onto more dimensions and checks that the code iterates
+    over those dimensions correctly. fAPAR and PPFD are then fixed across the other
+    dimensions to check the results scale as expected.
+    """
+
+    from pyrealm.pmodel import FastSlowScaler, PModel, PModelEnvironment
+    from pyrealm.pmodel.new_subdaily import SubdailyPModel
+
+    datetime = be_vie_data["time"].astype(np.datetime64)
+
+    # Set up the dimensionality for the test - create a shape tuple with extra
+    # dimensions and then broadcast the model inputs onto it. These need to be
+    # transposed to return datetime to the first axis. When n_dim = 1, the data are
+    # passed as is.
+    extra_dims = [3] * (ndims - 1)
+    array_dims = tuple(extra_dims + [len(datetime)])
+
+    # Create the environment
+    env = PModelEnvironment(
+        tc=np.broadcast_to(be_vie_data["ta"], array_dims).transpose(),
+        vpd=np.broadcast_to(be_vie_data["vpd"], array_dims).transpose(),
+        co2=np.broadcast_to(be_vie_data["co2"], array_dims).transpose(),
+        patm=np.broadcast_to(be_vie_data["patm"], array_dims).transpose(),
+    )
+
+    # Get the fast slow scaler and set window
+    fsscaler = FastSlowScaler(datetime)
+    fsscaler.set_window(
+        window_center=np.timedelta64(12, "h"),
+        half_width=np.timedelta64(30, "m"),
+    )
+
+    # Apply a different random value of fAPAR for each time series
+    fapar_vals = np.random.random(extra_dims)
+    fapar_vals[0] = 1.0
+
+    pmodel = PModel(env, kphio=1 / 8)
+    pmodel.estimate_productivity(
+        fapar=fapar_vals * np.ones(array_dims).transpose(),
+        ppfd=np.ones(array_dims).transpose(),
+    )
+    # Fast slow model
+    fs_pmodel = SubdailyPModel(
+        pmodel=pmodel,
+        fs_scaler=fsscaler,
+        handle_nan=True,
+    )
+
+    # The GPP along the timescale of the different dimensions should be directly
+    # proportional to the random fapar values and hence GPP/FAPAR should all equal the
+    # value when it is set to 1
+    timeaxis_mean = np.nansum(fs_pmodel.gpp, axis=0)
+    assert np.allclose(timeaxis_mean / fapar_vals, timeaxis_mean[0])
+
+
+@pytest.mark.parametrize("method_optchi", OPTIMAL_CHI_CLASS_REGISTRY.keys())
+def test_Subdaily_opt_chi_methods(be_vie_data_components, method_optchi):
+    """Tests that the SubdailyModel runs with all the provided optimal chi classes.
+
+    This currently just checks that the subdaily model _runs_ with each of the different
+    implementations of the OptimalChi ABC.
+    """
+
+    from pyrealm.pmodel import FastSlowScaler, PModel
+    from pyrealm.pmodel.new_subdaily import SubdailyPModel
+
+    env, ppfd, fapar, datetime, _ = be_vie_data_components
+
+    # Fit the standard P Model
+    pmodel = PModel(env=env, kphio=1 / 8, method_optchi=method_optchi)
+    pmodel.estimate_productivity(fapar=fapar, ppfd=ppfd)
+
+    # Get the fast slow scaler and set window
+    fsscaler = FastSlowScaler(datetime)
+    fsscaler.set_window(
+        window_center=np.timedelta64(12, "h"),
+        half_width=np.timedelta64(30, "m"),
+    )
+
+    # Run as a subdaily model and it should complete.
+    _ = SubdailyPModel(
+        pmodel=pmodel,
+        fs_scaler=fsscaler,
+        handle_nan=True,
+    )

--- a/tests/unit/pmodel/test_new_subdaily.py
+++ b/tests/unit/pmodel/test_new_subdaily.py
@@ -239,11 +239,11 @@ def test_Subdaily_opt_chi_methods(be_vie_data_components, method_optchi):
 
 
 @pytest.mark.parametrize("method_optchi", OPTIMAL_CHI_CLASS_REGISTRY.keys())
-def test_pmodel_to_subdaily(be_vie_data_components, method_optchi):
-    """Tests the pmodel_to_subdaily method."""
+def test_convert_pmodel_to_subdaily(be_vie_data_components, method_optchi):
+    """Tests the convert_pmodel_to_subdaily method."""
 
     from pyrealm.pmodel import FastSlowScaler, PModel
-    from pyrealm.pmodel.new_subdaily import SubdailyPModel, pmodel_to_subdaily
+    from pyrealm.pmodel.new_subdaily import SubdailyPModel, convert_pmodel_to_subdaily
 
     env, ppfd, fapar, datetime, _ = be_vie_data_components
 
@@ -268,7 +268,7 @@ def test_pmodel_to_subdaily(be_vie_data_components, method_optchi):
     standard_model = PModel(env=env, kphio=1 / 8, method_optchi=method_optchi)
     standard_model.estimate_productivity(fapar=fapar, ppfd=ppfd)
 
-    converted = pmodel_to_subdaily(
+    converted = convert_pmodel_to_subdaily(
         pmodel=standard_model, fs_scaler=fsscaler, handle_nan=True
     )
 


### PR DESCRIPTION
# Description

This PR builds on #172 to use the new `OptimalChi` methods to allow all approaches to be used in estimating a subdaily PModel. This radically simplifies the code compared to the current `FastSlowPModel` because all of the existing code within the `pmodel` module can be re-used more efficiently.

The PR:

* implements the new model class,
* adds a convenience conversion method to go from standard to subdaily models,
* adds a notebook showing the new approach,
* adds tests to show equivalence to the old approaches and to test the new interface with different optimal chi approaches.

Fixes #177 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
