### PR TITLE
 Attempting to make PModelConst inherit CoreConst

### DIFF
--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -174,7 +174,7 @@ the Arrhenius equation ($h^{-1}$ in {cite}`mengoli:2022a`).
 ha_vcmax25 = 65330
 ha_jmax25 = 43900
 
-tk_acclim = temp_acclim + pmodel_subdaily.env.core_const.k_CtoK
+tk_acclim = temp_acclim + pmodel_subdaily.env.const.k_CtoK
 vcmax25_acclim = pmodel_acclim.vcmax * (1 / calc_ftemp_arrh(tk_acclim, ha_vcmax25))
 jmax25_acclim = pmodel_acclim.jmax * (1 / calc_ftemp_arrh(tk_acclim, ha_jmax25))
 ```
@@ -230,7 +230,7 @@ temperature at fast scales:
   responses of $J_{max}$ and $V_{cmax}$.
 
 ```{code-cell} ipython3
-tk_subdaily = subdaily_env.tc + pmodel_subdaily.env.core_const.k_CtoK
+tk_subdaily = subdaily_env.tc + pmodel_subdaily.env.const.k_CtoK
 
 # Fill the realised jmax and vcmax from subdaily to daily
 vcmax25_subdaily = fsscaler.fill_daily_to_subdaily(vcmax25_real)
@@ -289,7 +289,7 @@ Aj_subdaily = (
 )
 
 # Calculate GPP and convert from micromols to micrograms
-GPP_subdaily = np.minimum(Ac_subdaily, Aj_subdaily) * pmodel_subdaily.env.core_const.k_c_molmass
+GPP_subdaily = np.minimum(Ac_subdaily, Aj_subdaily) * pmodel_subdaily.env.const.k_c_molmass
 
 # Compare to the SubdailyPModel outputs
 diff = GPP_subdaily - pmodel_subdaily.gpp

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -5,11 +5,11 @@ from dataclasses import dataclass, field
 import numpy as np
 from numpy.typing import NDArray
 
-from pyrealm.constants import ConstantsClass
+from pyrealm.constants import CoreConst
 
 
 @dataclass(frozen=True)
-class PModelConst(ConstantsClass):
+class PModelConst(CoreConst):
     r"""Constants for the P Model.
 
     This dataclass provides the following underlying constants used in calculating the

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -258,7 +258,6 @@ def calc_gammastar(
     tc: NDArray,
     patm: NDArray,
     pmodel_const: PModelConst = PModelConst(),
-    core_const: CoreConst = CoreConst(),
 ) -> NDArray:
     r"""Calculate the photorespiratory CO2 compensation point.
 
@@ -278,7 +277,6 @@ def calc_gammastar(
         tc: Temperature relevant for photosynthesis (:math:`T`, °C)
         patm: Atmospheric pressure (:math:`p`, Pascals)
         pmodel_const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-        core_const: Instance of :class:`~pyrealm.constants.core_const.CoreConst`.
 
     PModel Parameters:
         To: the standard reference temperature (:math:`T_0`. ``k_To``)
@@ -303,8 +301,8 @@ def calc_gammastar(
     return (
         pmodel_const.bernacchi_gs25_0
         * patm
-        / core_const.k_Po
-        * calc_ftemp_arrh((tc + core_const.k_CtoK), ha=pmodel_const.bernacchi_dha)
+        / pmodel_const.k_Po
+        * calc_ftemp_arrh((tc + pmodel_const.k_CtoK), ha=pmodel_const.bernacchi_dha)
     )
 
 
@@ -432,7 +430,6 @@ def calc_kp_c4(
     tc: NDArray,
     patm: NDArray,
     pmodel_const: PModelConst = PModelConst(),
-    core_const: CoreConst = CoreConst(),
 ) -> NDArray:
     r"""Calculate the Michaelis Menten coefficient of PEPc.
 
@@ -444,7 +441,6 @@ def calc_kp_c4(
         tc: Temperature, relevant for photosynthesis (:math:`T`, °C)
         patm: Atmospheric pressure (:math:`p`, Pa)
         pmodel_const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-        core_const: Instance of :class:`~pyrealm.constants.core_const.CoreConst`.
 
     PModel Parameters:
         hac: activation energy for :math:`\ce{CO2}` (:math:`H_{kc}`,
@@ -467,7 +463,7 @@ def calc_kp_c4(
     _ = check_input_shapes(tc, patm)
 
     # conversion to Kelvin
-    tk = tc + core_const.k_CtoK
+    tk = tc + pmodel_const.k_CtoK
     return pmodel_const.boyd_kp25_c4 * calc_ftemp_arrh(tk, ha=pmodel_const.boyd_dhac_c4)
 
 

--- a/pyrealm/pmodel/jmax_limitation.py
+++ b/pyrealm/pmodel/jmax_limitation.py
@@ -86,7 +86,7 @@ class JmaxLimitation:
         """Details of the optimal chi calculation for the model"""
         self.method: str = method
         """Records the method used to calculate Jmax limitation."""
-        self.pmodel_const: PModelConst = pmodel_const
+        self.const: PModelConst = pmodel_const
         """The PModelParams instance used for the calculation."""
 
         # Attributes populated by alternative method - two should always be populated by
@@ -148,14 +148,14 @@ class JmaxLimitation:
 
         # Calculate √ {1 – (c*/m)^(2/3)} (see Eqn 2 of Wang et al 2017) and
         # √ {(m/c*)^(2/3) - 1} safely, both are undefined where m <= c*.
-        vals_defined = np.greater(self.optchi.mj, self.pmodel_const.wang17_c)
+        vals_defined = np.greater(self.optchi.mj, self.const.wang17_c)
 
         self.f_v = np.sqrt(
-            1 - (self.pmodel_const.wang17_c / self.optchi.mj) ** (2.0 / 3.0),
+            1 - (self.const.wang17_c / self.optchi.mj) ** (2.0 / 3.0),
             where=vals_defined,
         )
         self.f_j = np.sqrt(
-            (self.optchi.mj / self.pmodel_const.wang17_c) ** (2.0 / 3.0) - 1,
+            (self.optchi.mj / self.const.wang17_c) ** (2.0 / 3.0) - 1,
             where=vals_defined,
         )
 
@@ -208,12 +208,12 @@ class JmaxLimitation:
 
         # Adopted from Nick Smith's code:
         # Calculate omega, see Smith et al., 2019 Ecology Letters  # Eq. S4
-        theta = self.pmodel_const.smith19_theta
-        c_cost = self.pmodel_const.smith19_c_cost
+        theta = self.const.smith19_theta
+        c_cost = self.const.smith19_c_cost
 
         # simplification terms for omega calculation
         cm = 4 * c_cost / self.optchi.mj
-        v = 1 / (cm * (1 - self.pmodel_const.smith19_theta * cm)) - 4 * theta
+        v = 1 / (cm * (1 - self.const.smith19_theta * cm)) - 4 * theta
 
         # account for non-linearities at low m values. This code finds
         # the roots of a quadratic function that is defined purely from

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -104,7 +104,7 @@ class OptimalChiABC(ABC):
         self.shape: tuple[int, ...] = env.shape
         """The shape of the input environment data."""
 
-        self.pmodel_const: PModelConst = pmodel_const
+        self.const: PModelConst = pmodel_const
         """The PModelParams used for optimal chi estimation"""
 
         # Declare attributes populated by methods. These are typed but not assigned a
@@ -249,7 +249,7 @@ class OptimalChiPrentice14(
     def set_beta(self) -> None:
         """Set ``beta`` to a constant C3 specific value."""
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.beta = self.pmodel_const.beta_cost_ratio_prentice14
+        self.beta = self.const.beta_cost_ratio_prentice14
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
         """Estimate ``chi`` for C3 plants."""
@@ -318,7 +318,7 @@ class OptimalChiPrentice14RootzoneStress(
         )
 
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.beta = self.pmodel_const.beta_cost_ratio_prentice14
+        self.beta = self.const.beta_cost_ratio_prentice14
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
         """Estimate ``chi`` for C3 plants."""
@@ -381,7 +381,7 @@ class OptimalChiC4(
     def set_beta(self) -> None:
         """Set ``beta`` to a constant C4 specific value."""
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.beta = self.pmodel_const.beta_cost_ratio_c4
+        self.beta = self.const.beta_cost_ratio_c4
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
         """Estimate ``chi`` for C4 plants, setting ``mj`` and ``mc`` to 1."""
@@ -448,7 +448,7 @@ class OptimalChiC4RootzoneStress(
     def set_beta(self) -> None:
         """Set ``beta`` to a constant C4 specific value."""
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.beta = self.pmodel_const.beta_cost_ratio_c4
+        self.beta = self.const.beta_cost_ratio_c4
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
         """Estimate ``chi`` for C4 plants, setting ``mj`` and ``mc`` to 1."""
@@ -531,8 +531,8 @@ class OptimalChiLavergne20C3(
         # Calculate beta as a function of theta, which is guaranteed not to be None by
         # _check_requires so supress mypy here
         self.beta = np.exp(
-            self.pmodel_const.lavergne_2020_b_c3 * self.env.theta  # type: ignore[operator] # noqa: E501
-            + self.pmodel_const.lavergne_2020_a_c3
+            self.const.lavergne_2020_b_c3 * self.env.theta  # type: ignore[operator] # noqa: E501
+            + self.const.lavergne_2020_a_c3
         )
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
@@ -623,8 +623,8 @@ class OptimalChiLavergne20C4(
         # Calculate beta as a function of theta, which is guaranteed not to be None by
         # _check_requires so supress mypy here
         self.beta = np.exp(
-            self.pmodel_const.lavergne_2020_b_c4 * self.env.theta  # type: ignore[operator] # noqa: E501
-            + self.pmodel_const.lavergne_2020_a_c4
+            self.const.lavergne_2020_b_c4 * self.env.theta  # type: ignore[operator] # noqa: E501
+            + self.const.lavergne_2020_a_c4
         )
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
@@ -702,7 +702,7 @@ class OptimalChiC4NoGamma(
         """Set constant ``beta`` for C4 plants."""
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
-        self.beta = self.pmodel_const.beta_cost_ratio_c4
+        self.beta = self.const.beta_cost_ratio_c4
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
         """Estimate ``chi`` for C4 plants excluding photorespiration."""
@@ -771,7 +771,7 @@ class OptimalChiC4NoGammaRootzoneStress(
         """Set constant ``beta`` for C4 plants."""
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
-        self.beta = self.pmodel_const.beta_cost_ratio_c4
+        self.beta = self.const.beta_cost_ratio_c4
 
     def estimate_chi(self, xi_values: Optional[NDArray] = None) -> None:
         """Estimate ``chi`` for C4 plants excluding photorespiration."""

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -11,7 +11,7 @@ from warnings import warn
 import numpy as np
 from numpy.typing import NDArray
 
-from pyrealm.constants import CoreConst, PModelConst
+from pyrealm.constants import PModelConst
 from pyrealm.core.utilities import check_input_shapes, summarize_attrs
 from pyrealm.pmodel.functions import (
     calc_ftemp_inst_rd,
@@ -200,10 +200,8 @@ class PModel:
         self.env: PModelEnvironment = env
         """The PModelEnvironment used to fit the P Model."""
 
-        self.pmodel_const: PModelConst = env.pmodel_const
+        self.const: PModelConst = env.const
         """The PModelConst instance used to create the model environment."""
-        self.core_const: CoreConst = env.core_const
-        """The CoreConst instance used to create the model environment."""
 
         # kphio calculation:
         self.init_kphio: float
@@ -236,7 +234,7 @@ class PModel:
 
         self.optchi: OptimalChiABC = opt_chi_class(
             env=env,
-            pmodel_const=self.pmodel_const,
+            pmodel_const=self.const,
         )
         """An subclass OptimalChi, implementing the requested chi calculation method"""
 
@@ -247,9 +245,7 @@ class PModel:
         # Temperature dependence of quantum yield efficiency
         # -----------------------------------------------------------------------
         if self.do_ftemp_kphio:
-            ftemp_kphio = calc_ftemp_kphio(
-                env.tc, self.c4, pmodel_const=self.pmodel_const
-            )
+            ftemp_kphio = calc_ftemp_kphio(env.tc, self.c4, pmodel_const=self.const)
             self.kphio = self.init_kphio * ftemp_kphio
         else:
             self.kphio = np.array([self.init_kphio])
@@ -261,7 +257,7 @@ class PModel:
         """Records the method used to calculate Jmax limitation."""
 
         self.jmaxlim: JmaxLimitation = JmaxLimitation(
-            self.optchi, method=self.method_jmaxlim, pmodel_const=self.pmodel_const
+            self.optchi, method=self.method_jmaxlim, pmodel_const=self.const
         )
         """Details of the Jmax limitation calculation for the model"""
         # -----------------------------------------------------------------------
@@ -280,7 +276,7 @@ class PModel:
         # The basic calculation of LUE = phi0 * M_c * m with an added penalty term
         # for jmax limitation
         self.lue: NDArray = (
-            self.kphio * self.optchi.mj * self.jmaxlim.f_v * self.core_const.k_c_molmass
+            self.kphio * self.optchi.mj * self.jmaxlim.f_v * self.const.k_c_molmass
         )
         """Light use efficiency (LUE, g C mol-1)"""
 
@@ -404,14 +400,14 @@ class PModel:
 
         # V_cmax25 (vcmax normalized to const.k_To)
         ftemp25_inst_vcmax = calc_ftemp_inst_vcmax(
-            self.env.tc, core_const=self.core_const, pmodel_const=self.pmodel_const
+            self.env.tc, core_const=self.const, pmodel_const=self.const
         )
         self._vcmax25 = self._vcmax / ftemp25_inst_vcmax
 
         # Dark respiration at growth temperature
-        ftemp_inst_rd = calc_ftemp_inst_rd(self.env.tc, pmodel_const=self.pmodel_const)
+        ftemp_inst_rd = calc_ftemp_inst_rd(self.env.tc, pmodel_const=self.const)
         self._rd = (
-            self.pmodel_const.atkin_rd_to_vcmax
+            self.const.atkin_rd_to_vcmax
             * (ftemp_inst_rd / ftemp25_inst_vcmax)
             * self._vcmax
         )
@@ -425,9 +421,7 @@ class PModel:
 
         assim = np.minimum(a_j, a_c)
 
-        if not np.allclose(
-            assim, self._gpp / self.core_const.k_c_molmass, equal_nan=True
-        ):
+        if not np.allclose(assim, self._gpp / self.const.k_c_molmass, equal_nan=True):
             warn("Assimilation and GPP are not identical")
 
         # Stomatal conductance - do not estimate when VPD = 0 or when floating point

--- a/pyrealm/pmodel/pmodel_environment.py
+++ b/pyrealm/pmodel/pmodel_environment.py
@@ -10,7 +10,7 @@ from typing import Optional
 import numpy as np
 from numpy.typing import NDArray
 
-from pyrealm.constants import CoreConst, PModelConst
+from pyrealm.constants import PModelConst
 from pyrealm.core.utilities import bounds_checker, check_input_shapes, summarize_attrs
 from pyrealm.pmodel.functions import (
     calc_co2_to_ca,
@@ -84,7 +84,7 @@ class PModelEnvironment:
         theta: Optional[NDArray] = None,
         rootzonestress: Optional[NDArray] = None,
         pmodel_const: PModelConst = PModelConst(),
-        core_const: CoreConst = CoreConst(),
+        # core_const: CoreConst = CoreConst(),
     ):
         self.shape: tuple = check_input_shapes(tc, vpd, co2, patm)
 
@@ -115,12 +115,10 @@ class PModelEnvironment:
         self.ca: NDArray = calc_co2_to_ca(self.co2, self.patm)
         """Ambient CO2 partial pressure, Pa"""
 
-        self.gammastar = calc_gammastar(
-            tc, patm, pmodel_const=pmodel_const, core_const=core_const
-        )
+        self.gammastar = calc_gammastar(tc, patm, pmodel_const=pmodel_const)
         r"""Photorespiratory compensation point (:math:`\Gamma^\ast`, Pa)"""
 
-        self.kmm = calc_kmm(tc, patm, pmodel_const=pmodel_const, core_const=core_const)
+        self.kmm = calc_kmm(tc, patm, pmodel_const=pmodel_const)
         """Michaelis Menten coefficient, Pa"""
 
         # # Michaelis-Menten coef. C4 plants (Pa) NOT CHECKED. Need to think
@@ -129,7 +127,7 @@ class PModelEnvironment:
         # # has not yet been implemented.
         # self.kp_c4 = calc_kp_c4(tc, patm, const=const)
 
-        self.ns_star = calc_ns_star(tc, patm, core_const=core_const)
+        self.ns_star = calc_ns_star(tc, patm, core_const=pmodel_const)
         """Viscosity correction factor realtive to standard
         temperature and pressure, unitless"""
 
@@ -152,10 +150,8 @@ class PModelEnvironment:
             )
 
         # Store constant settings
-        self.pmodel_const = pmodel_const
+        self.const = pmodel_const
         """PModel constants used to calculate environment"""
-        self.core_const = core_const
-        """Core constants used to calculate environment"""
 
     def __repr__(self) -> str:
         """Generates a string representation of PModelEnvironment instance."""

--- a/pyrealm/pmodel/subdaily.py
+++ b/pyrealm/pmodel/subdaily.py
@@ -279,8 +279,7 @@ class SubdailyPModel:
 
         pmodel_env_acclim = PModelEnvironment(
             **daily_environment,
-            pmodel_const=self.env.pmodel_const,
-            core_const=self.env.core_const,
+            pmodel_const=self.env.const,
         )
 
         # 2) Fit a PModel to those environmental conditions, using the supplied settings
@@ -315,12 +314,12 @@ class SubdailyPModel:
         )
 
         # 4) Calculate the optimal jmax and vcmax at 25°C
-        tk_acclim = pmodel_env_acclim.tc + self.env.core_const.k_CtoK
+        tk_acclim = pmodel_env_acclim.tc + self.env.const.k_CtoK
         self.vcmax25_opt = self.pmodel_acclim.vcmax * (
-            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_vcmax25_ha)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.const.subdaily_vcmax25_ha)
         )
         self.jmax25_opt = self.pmodel_acclim.jmax * (
-            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_jmax25_ha)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.const.subdaily_jmax25_ha)
         )
 
         # 5) Calculate the realised daily values from the instantaneous optimal values
@@ -345,21 +344,19 @@ class SubdailyPModel:
 
         # 7) Adjust subdaily jmax25 and vcmax25 back to jmax and vcmax given the
         #    actual subdaily temperatures.
-        subdaily_tk = self.env.tc + self.env.core_const.k_CtoK
+        subdaily_tk = self.env.tc + self.env.const.k_CtoK
         self.subdaily_vcmax: NDArray = self.subdaily_vcmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_vcmax25_ha
+            tk=subdaily_tk, ha=self.env.const.subdaily_vcmax25_ha
         )
         """Estimated subdaily :math:`V_{cmax}`."""
 
         self.subdaily_jmax: NDArray = self.subdaily_jmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_jmax25_ha
+            tk=subdaily_tk, ha=self.env.const.subdaily_jmax25_ha
         )
         """Estimated subdaily :math:`J_{max}`."""
 
         # 8) Recalculate chi using the OptimalChi class from the provided method.
-        self.optimal_chi = optimal_chi_class(
-            env=self.env, pmodel_const=env.pmodel_const
-        )
+        self.optimal_chi = optimal_chi_class(env=self.env, pmodel_const=env.const)
         self.optimal_chi.estimate_chi(xi_values=self.subdaily_xi)
 
         """Estimated subdaily :math:`c_i`."""
@@ -367,7 +364,7 @@ class SubdailyPModel:
         # Calculate Ac, J and Aj at subdaily scale to calculate assimilation
         if self.do_ftemp_kphio:
             ftemp_kphio = calc_ftemp_kphio(
-                env.tc, optimal_chi_class.is_c4, pmodel_const=env.pmodel_const
+                env.tc, optimal_chi_class.is_c4, pmodel_const=env.const
             )
             self.kphio = self.init_kphio * ftemp_kphio
         else:
@@ -387,8 +384,7 @@ class SubdailyPModel:
 
         # Calculate GPP and convert from mol to gC
         self.gpp: NDArray = (
-            np.minimum(self.subdaily_Aj, self.subdaily_Ac)
-            * self.env.core_const.k_c_molmass
+            np.minimum(self.subdaily_Aj, self.subdaily_Ac) * self.env.const.k_c_molmass
         )
         """Estimated subdaily GPP."""
 
@@ -538,8 +534,7 @@ class SubdailyPModel_JAMES:
             vpd=vpd_acclim,
             co2=co2_acclim,
             patm=patm_acclim,
-            pmodel_const=self.env.pmodel_const,
-            core_const=self.env.core_const,
+            pmodel_const=self.env.const,
         )
         self.pmodel_acclim: PModel = PModel(pmodel_env_acclim, kphio=kphio)
         r"""P Model predictions for the daily acclimation conditions.
@@ -557,12 +552,12 @@ class SubdailyPModel_JAMES:
         )
 
         # Calculate the optimal jmax and vcmax at 25°C
-        tk_acclim = temp_acclim + self.env.core_const.k_CtoK
+        tk_acclim = temp_acclim + self.env.const.k_CtoK
         self.vcmax25_opt = self.pmodel_acclim.vcmax * (
-            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_vcmax25_ha)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.const.subdaily_vcmax25_ha)
         )
         self.jmax25_opt = self.pmodel_acclim.jmax * (
-            1 / calc_ftemp_arrh(tk_acclim, self.env.pmodel_const.subdaily_jmax25_ha)
+            1 / calc_ftemp_arrh(tk_acclim, self.env.const.subdaily_jmax25_ha)
         )
 
         # Calculate the realised values from the instantaneous optimal values
@@ -597,7 +592,7 @@ class SubdailyPModel_JAMES:
         """Estimated subdaily :math:`c_i`."""
 
         # Fill the daily realised values onto the subdaily scale
-        subdaily_tk = self.env.tc + self.env.core_const.k_CtoK
+        subdaily_tk = self.env.tc + self.env.const.k_CtoK
 
         # Fill the realised xi, jmax25 and vcmax25 from subdaily to daily and then
         # adjust jmax25 and vcmax25 to jmax and vcmax given actual temperature at
@@ -610,12 +605,12 @@ class SubdailyPModel_JAMES:
         )
 
         self.subdaily_vcmax: NDArray = self.subdaily_vcmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_vcmax25_ha
+            tk=subdaily_tk, ha=self.env.const.subdaily_vcmax25_ha
         )
         """Estimated subdaily :math:`V_{cmax}`."""
 
         self.subdaily_jmax: NDArray = self.subdaily_jmax25 * calc_ftemp_arrh(
-            tk=subdaily_tk, ha=self.env.pmodel_const.subdaily_jmax25_ha
+            tk=subdaily_tk, ha=self.env.const.subdaily_jmax25_ha
         )
         """Estimated subdaily :math:`J_{max}`."""
 
@@ -643,7 +638,6 @@ class SubdailyPModel_JAMES:
 
         # Calculate GPP, converting from mol m2 s1 to grams carbon m2 s1
         self.gpp: NDArray = (
-            np.minimum(self.subdaily_Aj, self.subdaily_Ac)
-            * self.env.core_const.k_c_molmass
+            np.minimum(self.subdaily_Aj, self.subdaily_Ac) * self.env.const.k_c_molmass
         )
         """Estimated subdaily GPP."""

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -481,7 +481,7 @@ def test_jmax_limitation(
         xf = 1
 
     expected_lue = (
-        (0.05 * ftemp_kphio) * optchi.mj * jmax.f_v * xf * env.core_const.k_c_molmass
+        (0.05 * ftemp_kphio) * optchi.mj * jmax.f_v * xf * env.const.k_c_molmass
     )
     assert np.allclose(expected_lue, expected["lue"], equal_nan=True)
 

--- a/tests/unit/pmodel/test_subdaily.py
+++ b/tests/unit/pmodel/test_subdaily.py
@@ -157,7 +157,7 @@ def test_SubdailyPModel_JAMES(be_vie_data_components):
     # and rounding of outputs prevent a closer match between the implementations
     assert np.allclose(
         fs_pmodel_james.gpp[valid],
-        expected_gpp[valid] * env.core_const.k_c_molmass,
+        expected_gpp[valid] * env.const.k_c_molmass,
         rtol=0.005,
     )
 
@@ -211,7 +211,7 @@ def test_FSPModel_corr(be_vie_data_components, data_args):
     )
 
     # Test that non-NaN predictions correlate well and are approximately the same
-    gpp_in_micromols = subdaily_pmodel.gpp[valid] / env.core_const.k_c_molmass
+    gpp_in_micromols = subdaily_pmodel.gpp[valid] / env.const.k_c_molmass
     assert np.allclose(gpp_in_micromols, expected_gpp[valid], rtol=0.2)
     r_vals = np.corrcoef(gpp_in_micromols, expected_gpp[valid])
     assert np.all(r_vals > 0.995)


### PR DESCRIPTION
Make PModelConst inherit CoreConst, and merge the usage of pmodel_const and core_const in PModelEnvironment.


# Description

Attempting to make PModelConst inherit CoreConst and merge their usages.

Fixes #161 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
