### PR TITLE
Python version bug in pyrealm_profiling.yaml

### DIFF
--- a/.github/workflows/pyrealm_profiling.yaml
+++ b/.github/workflows/pyrealm_profiling.yaml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install Poetry
       uses: abatilo/actions-poetry@v2.1.6


### PR DESCRIPTION
# Description

This PR just updates the python version on the profiling workflow so it is read as `"3.10"` not `3.1`


Fixes #213

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
