### PR TITLE
Simplify the jupyter kernelspec setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: 'bug'
 assignees: ''
-
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -70,9 +70,6 @@ jobs:
 
       - name: Install dependencies
         run: poetry install
-
-      - name: Set ipython kernel
-        run: poetry run python -m ipykernel install --user --name=pyrealm_python3
       
       - name: Build docs using sphinx
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,12 @@ repos:
     rev: v0.40.0
     hooks:
     - id: markdownlint
-
+  - repo: https://github.com/mwouts/jupytext
+    rev: v1.16.2
+    hooks:
+    - id: jupytext
+      args: [--pipe, black]
+      files: docs/source 
+      additional_dependencies:
+        - black==24.4.2 # Matches hook
+      

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,7 +22,6 @@ build:
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry run python -m ipykernel install --user --name=pyrealm_python3
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/api/constants_api.md
+++ b/docs/source/api/constants_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 

--- a/docs/source/api/constants_api.md
+++ b/docs/source/api/constants_api.md
@@ -5,13 +5,12 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
   name: python3
 ---
-
 
 # The {mod}`~pyrealm.constants` module
 

--- a/docs/source/api/core_api.md
+++ b/docs/source/api/core_api.md
@@ -5,13 +5,12 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
   name: python3
 ---
-
 
 # The {mod}`~pyrealm.core` module
 

--- a/docs/source/api/core_api.md
+++ b/docs/source/api/core_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 

--- a/docs/source/api/pmodel_api.md
+++ b/docs/source/api/pmodel_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The {mod}`~pyrealm.pmodel` module

--- a/docs/source/api/pmodel_api.md
+++ b/docs/source/api/pmodel_api.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/api/splash_api.md
+++ b/docs/source/api/splash_api.md
@@ -5,13 +5,12 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
   name: python3
 ---
-
 
 # The {mod}`~pyrealm.splash` module
 

--- a/docs/source/api/splash_api.md
+++ b/docs/source/api/splash_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 

--- a/docs/source/api/tmodel_api.md
+++ b/docs/source/api/tmodel_api.md
@@ -4,6 +4,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/api/tmodel_api.md
+++ b/docs/source/api/tmodel_api.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The {mod}`~pyrealm.tmodel` module

--- a/docs/source/development/code_qa_and_typing.md
+++ b/docs/source/development/code_qa_and_typing.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Code quality and static typing

--- a/docs/source/development/code_qa_and_typing.md
+++ b/docs/source/development/code_qa_and_typing.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/code_testing.md
+++ b/docs/source/development/code_testing.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Package testing and profiling

--- a/docs/source/development/code_testing.md
+++ b/docs/source/development/code_testing.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/documentation.md
+++ b/docs/source/development/documentation.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Documentation
@@ -60,7 +60,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 ```
 
@@ -132,12 +132,15 @@ docstrings. The `sphinx` building process requires some extra packages, but thes
 included in the `docs` group in `pyproject.toml` and should be installed.
 
 In order to build the package documentation, Jupyter needs to be able to associate the
-documentation files with the Python environment managed by `poetry`. This is done by
-installing the `poetry` environment as a new Jupyter kernel with a fixed name. This
-allows all build systems to run notebooks using the correct build environment:
+documentation files with the Python environment managed by `poetry`. Fortunately, the
+`poetry shell` and `poetry run` commands update the Jupyter kernel specifications so
+that the `python3` kernel name points to the `poetry` environment. For example:
 
 ```bash
-poetry run python -m ipykernel install --user --name=pyrealm_python3
+$ poetry run jupyter kernelspec list
+Available kernels:
+  ...
+  python3            /Users/dorme/Library/Caches/pypoetry/virtualenvs/pyrealm-QywIOHcp-py3.10/share/jupyter/kernels/python3
 ```
 
 In order to build the package documentation, the following command can then be used:

--- a/docs/source/development/documentation.md
+++ b/docs/source/development/documentation.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/github_actions.md
+++ b/docs/source/development/github_actions.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # GitHub Actions

--- a/docs/source/development/github_actions.md
+++ b/docs/source/development/github_actions.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/overview.md
+++ b/docs/source/development/overview.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -306,7 +306,7 @@ up everything you need, ready to start developing on pyrealm.
 :::{admonition} Setup script
 
 ``` sh
-#!/bin/bash
+!/bin/bash
 
 # pyenv and poetry use sqlite3. You _may_ need to install these requirements first.
 sudo apt install sqlite3 sqlite3-doc libsqlite3-dev

--- a/docs/source/development/overview.md
+++ b/docs/source/development/overview.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Developing `pyrealm`
@@ -272,23 +272,17 @@ package testing and in documentation.
 We use `sphinx` to maintain the documentation for `pyrealm` and Google style docstrings
 using the `napoleon` formatting to provide API documentation for the code. We use MyST
 Markdown to provide dynamically built usage examples. See the [documentation
-page](./documentation.md) for details.
-
-In order to build the documentation, you will need to register the `poetry` virtual
-enviroment, so that it can be used by `jupyter` and `myst` to build dynamic content.
-This only needs to be done once.
-
-```bash
-poetry run python -m ipykernel install --user --name=pyrealm_python3
-```
-
-After that, the following code can be used to build the documentation
+page](./documentation.md) for details but to get started, the following code can be used
+to build the documentation.
 
 ```bash
 # Build docs using sphinx
 cd docs
 poetry run sphinx-build -W --keep-going source build
 ```
+
+Once that command completes, the file `docs/build/html/index.html` can be opened to view
+the built documentation.
 
 ### GitHub Actions
 

--- a/docs/source/development/profiling_and_benchmarking.md
+++ b/docs/source/development/profiling_and_benchmarking.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -242,7 +242,7 @@ being profiled and using the default number of previous runs (5) and tolerance (
 poetry run python profiling/run_benchmarking.py \
        prof/combined.prof profiling/profiling-database.csv \
        profiling/benchmark-fails.csv 8c2cbfe \
-       --plot-path profiling/performance-plot.png --update-on-pass 
+       --plot-path profiling/performance-plot.png --update-on-pass
 ```
 
 The continuous integration process automatically commits the results of benchmarking

--- a/docs/source/development/profiling_and_benchmarking.md
+++ b/docs/source/development/profiling_and_benchmarking.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Profiling and benchmarking

--- a/docs/source/development/pyrealm_build_data.md
+++ b/docs/source/development/pyrealm_build_data.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The `pyrealm_build_data` package

--- a/docs/source/development/pyrealm_build_data.md
+++ b/docs/source/development/pyrealm_build_data.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/development/release_process.md
+++ b/docs/source/development/release_process.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Package release process

--- a/docs/source/development/release_process.md
+++ b/docs/source/development/release_process.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The `pyrealm` package

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,6 +4,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/users/constants.md
+++ b/docs/source/users/constants.md
@@ -4,6 +4,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -34,7 +36,7 @@ of default model constants. The core API and details for each class can be seen
 
 These can be used to generate the default set of model parameters:
 
-```{code-cell} python
+```{code-cell}
 from pyrealm.constants import CoreConst, TModelTraits
 
 core_const = CoreConst()
@@ -46,9 +48,9 @@ print(tmodel_const)
 
 And individual values can be altered using the parameter arguments:
 
-```{code-cell} python
+```{code-cell}
 # Estimate processes under the moon's gravity...
-core_const_moon = CoreConst(k_G = 1.62)
+core_const_moon = CoreConst(k_G=1.62)
 # ... allowing a much greater maximum height
 tmodel_const_moon = TModelTraits(h_max=200)
 
@@ -60,8 +62,9 @@ In order to ensure that a set of parameters cannot change while models are being
 instances of these parameter classes are **frozen**. You cannot  edit an existing
 instance and will need to create a new instance to use different parameters.
 
-```{code-cell} python
-:tags: ["raises-exception"]
+```{code-cell}
+:tags: [raises-exception]
+
 core_const_moon.k_G = 9.80665
 ```
 
@@ -73,10 +76,11 @@ export of parameter settings to dictionaries and to JSON formatted files. The co
 shows these methods working. First, a trait definition in a JSON file is read into a
 dictionary:
 
-```{code-cell} python
+```{code-cell}
 import json
 import pprint
-trt_dict = json.load(open('../files/traits.json', 'r'))
+
+trt_dict = json.load(open("../files/traits.json", "r"))
 pprint.pprint(trt_dict)
 ```
 
@@ -85,9 +89,9 @@ the {meth}`~pyrealm.constants.base.ConstantsClass.from_dict` method. The
 {meth}`~pyrealm.constants.base.ConstantsClass.from_json` method allows this to
 be done more directly and the resulting instances are identical.
 
-```{code-cell} python
+```{code-cell}
 traits1 = TModelTraits.from_dict(trt_dict)
-traits2 = TModelTraits.from_json('../files/traits.json')
+traits2 = TModelTraits.from_json("../files/traits.json")
 
 print(traits1)
 print(traits2)

--- a/docs/source/users/constants.md
+++ b/docs/source/users/constants.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Package constants

--- a/docs/source/users/hygro.md
+++ b/docs/source/users/hygro.md
@@ -4,8 +4,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
-    format_version: 0.12
-    jupytext_version: 1.6.0
+    format_version: 0.13
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -14,7 +14,7 @@ kernelspec:
 
 # Hygrometric functions
 
-```{code-cell} ipython3
+```{code-cell}
 # This code loads required packages and then creates a representative range of
 # values of the core variables to use in function plots.
 #
@@ -25,6 +25,7 @@ kernelspec:
 from matplotlib import pyplot
 import numpy as np
 from pyrealm.core import hygro
+
 %matplotlib inline
 
 # Set the resolution of examples
@@ -72,51 +73,52 @@ and returns kPa, so if you are using VP to prepare input data for
 
 ## Saturated vapour pressure
 
-```{code-cell} ipython3
+```{code-cell}
 # Create a sequence of air temperatures and calculate the saturated vapour pressure
 vp_sat = hygro.calc_vp_sat(ta_1d)
 
 # Plot ta against vp_sat
 pyplot.plot(ta_1d, vp_sat)
-pyplot.xlabel('Temperature °C')
-pyplot.ylabel('Saturated vapour pressure (kPa)')
+pyplot.xlabel("Temperature °C")
+pyplot.ylabel("Saturated vapour pressure (kPa)")
 pyplot.show()
 ```
 
 ## Vapour pressure to VPD
 
-```{code-cell} ipython3
+```{code-cell}
 vpd = hygro.convert_vp_to_vpd(vp_2d, ta_2d.transpose())
 
 # Plot vpd
 fig, ax = pyplot.subplots()
-CS = ax.contour(vp_1d, ta_1d, vpd, colors='black')
+CS = ax.contour(vp_1d, ta_1d, vpd, colors="black")
 ax.clabel(CS, inline=1, fontsize=10)
-ax.set_title('Converting VP to VPD')
-ax.set_xlabel('Vapour Pressure (kPa)')
-ax.set_ylabel('Temperature (°C)')
+ax.set_title("Converting VP to VPD")
+ax.set_xlabel("Vapour Pressure (kPa)")
+ax.set_ylabel("Temperature (°C)")
 pyplot.show()
 ```
 
 ## Relative humidity to VPD
 
-```{code-cell} ipython3
+```{code-cell}
 vpd = hygro.convert_rh_to_vpd(rh_2d, ta_2d.transpose())
 
 # Plot vpd
 fig, ax = pyplot.subplots()
-CS = ax.contour(rh_1d, ta_1d, vpd, colors='black',
-                levels=[0,0.1,0.5,1,2.5,5,10,15])
+CS = ax.contour(
+    rh_1d, ta_1d, vpd, colors="black", levels=[0, 0.1, 0.5, 1, 2.5, 5, 10, 15]
+)
 ax.clabel(CS, inline=1, fontsize=10)
-ax.set_title('Converting RH to VPD')
-ax.set_xlabel('Relative humidity (-)')
-ax.set_ylabel('Temperature (°C)')
+ax.set_title("Converting RH to VPD")
+ax.set_xlabel("Relative humidity (-)")
+ax.set_ylabel("Temperature (°C)")
 pyplot.show()
 ```
 
 ## Specific humidity to VPD
 
-```{code-cell} ipython3
+```{code-cell}
 # Create a sequence of air temperatures and calculate the saturated vapour pressure
 vpd1 = hygro.convert_sh_to_vpd(sh_1d, ta=20, patm=101.325)
 vpd2 = hygro.convert_sh_to_vpd(sh_1d, ta=30, patm=101.325)
@@ -124,14 +126,15 @@ vpd3 = hygro.convert_sh_to_vpd(sh_1d, ta=20, patm=90)
 vpd4 = hygro.convert_sh_to_vpd(sh_1d, ta=30, patm=90)
 
 
-for yvals, lab in zip([vpd1, vpd2, vpd3, vpd4],
-                      ['20°C, 101.325 kPa', '30°C, 101.325 kPa',
-                       '20°C, 90 kPa', '20°C, 90 kPa']):
+for yvals, lab in zip(
+    [vpd1, vpd2, vpd3, vpd4],
+    ["20°C, 101.325 kPa", "30°C, 101.325 kPa", "20°C, 90 kPa", "20°C, 90 kPa"],
+):
     pyplot.plot(sh_1d, yvals, label=lab)
 
-pyplot.title('Converting SH to VPD')
+pyplot.title("Converting SH to VPD")
 pyplot.legend(frameon=False)
-pyplot.xlabel('Specific humidity (kg kg-1)')
-pyplot.ylabel('Vapour pressure deficit (kPa)')
+pyplot.xlabel("Specific humidity (kg kg-1)")
+pyplot.ylabel("Vapour pressure deficit (kPa)")
 pyplot.show()
 ```

--- a/docs/source/users/hygro.md
+++ b/docs/source/users/hygro.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Hygrometric functions

--- a/docs/source/users/pmodel/c3c4model.md
+++ b/docs/source/users/pmodel/c3c4model.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.8
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # C3 / C4 Competition

--- a/docs/source/users/pmodel/c3c4model.md
+++ b/docs/source/users/pmodel/c3c4model.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -74,7 +74,7 @@ pyplot.legend(title="Forest cover", frameon=False)
 pyplot.title(r"Initial C4 fraction prediction from $A_4$ and tree cover")
 pyplot.xlabel("Proportion C4 GPP advantage $A_4$")
 pyplot.ylabel("Expected C4 fraction ($F_4$)")
-pyplot.axvline(0, ls="--", c="grey");
+pyplot.axvline(0, ls="--", c="grey")
 ```
 
 ## Step 3: Account for shading by C3 trees
@@ -99,7 +99,7 @@ pyplot.axvline(2.8, ls="--", c="grey")
 
 pyplot.title("Proportion of GPP from C3 trees")
 pyplot.xlabel("GPP from C3 plants (kg m-2 yr-1)")
-pyplot.ylabel("Proportion of GPP from C3 trees (h, -)");
+pyplot.ylabel("Proportion of GPP from C3 trees (h, -)")
 ```
 
 ## Step 4: Filtering cold areas and cropland

--- a/docs/source/users/pmodel/isotopic_discrimination.md
+++ b/docs/source/users/pmodel/isotopic_discrimination.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Isotopic discrimination

--- a/docs/source/users/pmodel/isotopic_discrimination.md
+++ b/docs/source/users/pmodel/isotopic_discrimination.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/users/pmodel/module_overview.md
+++ b/docs/source/users/pmodel/module_overview.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The P Model module

--- a/docs/source/users/pmodel/module_overview.md
+++ b/docs/source/users/pmodel/module_overview.md
@@ -4,6 +4,8 @@ jupytext:
   text_representation:
     extension: .md
     format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
+++ b/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # P Model predictions

--- a/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
+++ b/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -39,9 +39,7 @@ co2_1d = np.array([280, 410])
 tc_4d, patm_4d, vpd_4d, co2_4d = np.meshgrid(tc_1d, patm_1d, vpd_1d, co2_1d)
 
 # Calculate the photosynthetic environment
-pmodel_env = PModelEnvironment(tc=tc_4d, patm=patm_4d, 
-vpd=vpd_4d, 
-    co2=co2_4d)
+pmodel_env = PModelEnvironment(tc=tc_4d, patm=patm_4d, vpd=vpd_4d, co2=co2_4d)
 
 # Run the P Models
 pmodel_c3 = PModel(pmodel_env)
@@ -223,7 +221,7 @@ must be expressed as $\boldsymbol{\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{
 Estimates of PPFD sometimes use different temporal or spatial scales - for
 example daily moles of photons per hectare. Although GPP can also be expressed
 with different units, many other predictions of the P Model ($J_{max}$,
-$V_{cmax}$, $g_s$ and $r_d$) _must_ be expressed as 
+$V_{cmax}$, $g_s$ and $r_d$) _must_ be expressed as
 $\mu\text{mol}\,\mathrm{m}^{-2}\,\text{s}^{-1}$ and so this
 standard unit must also be used for PPFD.
 ```
@@ -279,7 +277,9 @@ plot_fun("vcmax", r"$v_{cmax}$   ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^
 ```{code-cell}
 :tags: [hide-input]
 
-plot_fun("vcmax25", r"$v_{cmax25}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)")
+plot_fun(
+    "vcmax25", r"$v_{cmax25}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+)
 ```
 
 ### Maximum rate of electron transport. (``jmax``)
@@ -352,15 +352,15 @@ def plot_iabs(ax, estvar, estvarlab):
 fig, axs = pyplot.subplots(2, 3, figsize=(12, 8), sharex=True)
 
 plot_iabs(
-    axs[0, 0],
-    "gpp",
-     r"GPP ($\mu\mathrm{g\,C}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)")
-plot_iabs(axs[0, 1],
-    "rd",
-     r"$r_d$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)")
-plot_iabs(axs[0, 2],
+    axs[0, 0], "gpp", r"GPP ($\mu\mathrm{g\,C}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+)
+plot_iabs(
+    axs[0, 1], "rd", r"$r_d$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+)
+plot_iabs(
+    axs[0, 2],
     "vcmax",
-     r"$v_{cmax}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+    r"$v_{cmax}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)",
 )
 plot_iabs(
     axs[1, 0],
@@ -368,14 +368,13 @@ plot_iabs(
     r"$v_{cmax25}$   ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)",
 )
 plot_iabs(
-    axs[1, 1], 
+    axs[1, 1],
     "jmax",
-    r"$J_{max}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+    r"$J_{max}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)",
 )
-plot_iabs(axs[1, 2],
-    "gs",
-    r"$g_s$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
-    )
+plot_iabs(
+    axs[1, 2], "gs", r"$g_s$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+)
 
 axs[0, 0].legend(
     [

--- a/docs/source/users/pmodel/pmodel_details/extreme_values.md
+++ b/docs/source/users/pmodel/pmodel_details/extreme_values.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Extreme forcing values

--- a/docs/source/users/pmodel/pmodel_details/extreme_values.md
+++ b/docs/source/users/pmodel/pmodel_details/extreme_values.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/users/pmodel/pmodel_details/lue_limitation.md
+++ b/docs/source/users/pmodel/pmodel_details/lue_limitation.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # LUE Limitation

--- a/docs/source/users/pmodel/pmodel_details/lue_limitation.md
+++ b/docs/source/users/pmodel/pmodel_details/lue_limitation.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/users/pmodel/pmodel_details/optimal_chi.md
+++ b/docs/source/users/pmodel/pmodel_details/optimal_chi.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.1
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -64,7 +64,7 @@ for use within a P Model.
   - {class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4NoGammaRootzoneStress`
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 from itertools import product
@@ -92,6 +92,7 @@ tc_4d, patm_4d, vpd_4d, co2_4d = np.meshgrid(tc_1d, patm_1d, vpd_1d, co2_1d)
 
 # Calculate the photosynthetic environment
 pmodel_env = PModelEnvironment(tc=tc_4d, patm=patm_4d, vpd=vpd_4d, co2=co2_4d)
+
 
 # A plotter function for a model
 def plot_opt_chi(mod):
@@ -196,7 +197,7 @@ def plot_opt_chi(mod):
 This **C3 method** follows the approach detailed in {cite:t}`Prentice:2014bc`, see
 {class}`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14` for details.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Run the P Model and plot predictions
@@ -210,7 +211,7 @@ This **C4 method** follows the approach detailed in {cite:t}`Prentice:2014bc`, b
 a C4 specific version of the unit cost ratio ($\beta$). It also sets $m_j = m_c = 1$.
 See {class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4` for details.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Run the P Model and plot predictions
@@ -228,7 +229,7 @@ and also also sets $m_j = 1$, but $m_c$ is calculated as in
 {class}`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14`. See
 {meth}`~pyrealm.pmodel.optimal_chi.OptimalChiC4NoGamma` for details.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Run the P Model and plot predictions
@@ -249,11 +250,11 @@ but $m_j=1$.
 ```{warning}
 Note that {cite:t}`lavergne:2020a` found **no relationship** between C4 $\beta$
 values and soil moisture in leaf gas exchange data  The
-{class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4` method is **an 
+{class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4` method is **an
 experimental
 feature** - see the documentation for the
 {class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4` and
-{class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4` methods for the theoretical 
+{class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4` methods for the theoretical
 rationale.
 ```
 
@@ -263,7 +264,7 @@ The calculation details are provided in the description of the
 {class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C3` method, but the
 variation in $\beta$ with $\theta$ is shown below.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Theta is required for the calculation of beta
@@ -291,7 +292,7 @@ The plots below show the impacts on optimal $\chi$ across a temperature gradient
 values of VPD and soil moisture, with constant atmospheric pressure (101325 Pa) and CO2
 (280 ppm).
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Environments with high and low soil moisture
@@ -356,7 +357,7 @@ pyplot.tight_layout()
 The plots below illustrate the impact of temperature and  $\theta$ on  $m_j$ and $m_c$,
 again with constant atmospheric pressure (101325 Pa) and CO2 (280 ppm).
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 fig, ((ax1, ax3), (ax2, ax4)) = pyplot.subplots(2, 2, figsize=(10, 10), sharey=True)
@@ -454,22 +455,22 @@ but the variation in $\beta$ with rootzone stress is shown below.
 * {class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4RootzoneStress`
 * {class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4NoGammaRootzoneStress`
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 from pyrealm.pmodel.optimal_chi import (
-  OptimalChiPrentice14RootzoneStress,
-  OptimalChiC4RootzoneStress,
-  OptimalChiC4NoGammaRootzoneStress,
+    OptimalChiPrentice14RootzoneStress,
+    OptimalChiC4RootzoneStress,
+    OptimalChiC4NoGammaRootzoneStress,
 )
 
 # Rootzone stress is required for the calculation of beta
 pmodel_env_rootzonestress = PModelEnvironment(
-    tc=np.repeat(25, 101), 
-    patm=np.repeat(101325, 101), 
+    tc=np.repeat(25, 101),
+    patm=np.repeat(101325, 101),
     vpd=np.repeat(1000, 101),
-    co2=np.repeat(400, 101), 
-    rootzonestress=np.linspace(0, 1, 101)
+    co2=np.repeat(400, 101),
+    rootzonestress=np.linspace(0, 1, 101),
 )
 
 # Estimate using the 3 different methods
@@ -480,19 +481,13 @@ opt_chi_c4_no_gamma_rzs = OptimalChiC4NoGammaRootzoneStress(pmodel_env_rootzones
 # Plot the predictions
 fig, ax1 = pyplot.subplots(1, 1, figsize=(6, 4))
 ax1.plot(
-  pmodel_env_rootzonestress.rootzonestress, 
-  opt_chi_prentice14_rzs.xi, 
-  label="C3"
+    pmodel_env_rootzonestress.rootzonestress, opt_chi_prentice14_rzs.xi, label="C3"
 )
+ax1.plot(pmodel_env_rootzonestress.rootzonestress, opt_chi_c4_rzs.xi, label="C4")
 ax1.plot(
-  pmodel_env_rootzonestress.rootzonestress, 
-  opt_chi_c4_rzs.xi, 
-  label="C4"
-)
-ax1.plot(
-  pmodel_env_rootzonestress.rootzonestress, 
-  opt_chi_c4_no_gamma_rzs.xi, 
-  label="C4 no gamma"
+    pmodel_env_rootzonestress.rootzonestress,
+    opt_chi_c4_no_gamma_rzs.xi,
+    label="C4 no gamma",
 )
 ax1.set_xlabel(r"Rootzone stress factor (-)")
 ax1.set_ylabel(r"``xi`` parameter ($\xi$, -)")
@@ -506,7 +501,7 @@ The plots below show the impacts on optimal $\chi$ across a temperature gradient
 values of VPD and rootzone stress, with constant atmospheric pressure (101325 Pa) and CO2
 (280 ppm).
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Environments with high and low rootzone stress

--- a/docs/source/users/pmodel/pmodel_details/optimal_chi.md
+++ b/docs/source/users/pmodel/pmodel_details/optimal_chi.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.1
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Optimal $\chi$ and leaf $\ce{CO2}$

--- a/docs/source/users/pmodel/pmodel_details/photosynthetic_environment.md
+++ b/docs/source/users/pmodel/pmodel_details/photosynthetic_environment.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Photosynthetic environment

--- a/docs/source/users/pmodel/pmodel_details/photosynthetic_environment.md
+++ b/docs/source/users/pmodel/pmodel_details/photosynthetic_environment.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -27,7 +27,7 @@ The descriptions below show the typical ranges of these values under common
 environmental inputs along with links to the more detailed documentation of
 the key functions.
 
-```{code-cell} python
+```{code-cell}
 :tags: [hide-input]
 
 # This code loads required packages and then creates a representative range of
@@ -69,7 +69,7 @@ Details: {func}`pyrealm.pmodel.functions.calc_gammastar`
 The photorespiratory compensation point ($\Gamma^*$) varies with as a function
 of temperature and atmospheric pressure:
 
-```{code-cell} python
+```{code-cell}
 :tags: [hide-input]
 
 # Calculate gammastar
@@ -92,7 +92,7 @@ Details: {func}`pyrealm.pmodel.functions.calc_kmm`
 The Michaelis-Menten coefficient for photosynthesis ($K_{mm}$) also varies with
 temperature and atmospheric pressure:
 
-```{code-cell} python
+```{code-cell}
 :tags: [hide-input]
 
 # Calculate K_mm
@@ -119,7 +119,7 @@ pressure ($\eta^*$).
 
 The figure shows how $\eta^*$ varies with temperature and pressure.
 
-```{code-cell} python
+```{code-cell}
 :tags: [hide-input]
 
 # Calculate the viscosity under the range of values and the standard
@@ -147,7 +147,7 @@ Details: {func}`pyrealm.pmodel.functions.calc_co2_to_ca`
 The partial pressure of $\ce{CO2}$ is a function of the atmospheric concentration of
 $\ce{CO2}$ in parts per million and the atmospheric pressure:
 
-```{code-cell} python
+```{code-cell}
 :tags: [hide-input]
 
 # Variation in partial pressure

--- a/docs/source/users/pmodel/pmodel_details/pmodel_overview.md
+++ b/docs/source/users/pmodel/pmodel_details/pmodel_overview.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -50,7 +50,7 @@ The main steps are:
 
 * Constraints on [light use efficiency (LUE)](lue_limitation). The calculation of light
   use efficiency can be subjected to a number of constraints:
-  
+
   * Theoretical limitations to the maximum rates of Rubsico regeneration
     ($J_{max}$) and maximum carboxylation capacity ($V_{cmax}$)
 

--- a/docs/source/users/pmodel/pmodel_details/pmodel_overview.md
+++ b/docs/source/users/pmodel/pmodel_details/pmodel_overview.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 <!-- markdownlint-disable-next-line MD041 -->

--- a/docs/source/users/pmodel/pmodel_details/rpmodel.md
+++ b/docs/source/users/pmodel/pmodel_details/rpmodel.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The `rpmodel` implementation

--- a/docs/source/users/pmodel/pmodel_details/rpmodel.md
+++ b/docs/source/users/pmodel/pmodel_details/rpmodel.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.1
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Soil moisture effects

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.1
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -86,7 +86,7 @@ varies with changing soil moisture for some different values of mean aridity. In
 the examples below, the default $\theta_0 = 0$ has been changed to $\theta_0 =
 0.1$ to make the lower bound more obvious.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 from matplotlib import pyplot as plt
@@ -152,7 +152,7 @@ by the resulting factor. The example below shows how the predicted light use
 efficiency from the P Model changes across an aridity gradient both with and without the
 soil moisture factor.
 
-```{code-cell} ipython3
+```{code-cell}
 # Calculate the P Model in a constant environment
 tc = np.array([20] * 101)
 sm_gradient = np.linspace(0, 1.0, 101)
@@ -175,7 +175,7 @@ for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
     gpp_stressed[mean_alpha] = model.gpp * sm_stress
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 plt.plot(sm_gradient, model.gpp, label="No soil moisture penalty")
@@ -235,15 +235,15 @@ y &= \min( a  \textrm{AI} ^ {b}, 1)\\
 \end{align*}
 $$
 
-```{code-cell} ipython3
+```{code-cell}
 from pyrealm.constants import PModelConst
 
-const=PModelConst()
+const = PModelConst()
 aridity_index = np.arange(0.35, 7, 0.1)
 
 y = np.minimum(
-        const.soilm_mengoli_y_a * np.power(aridity_index, const.soilm_mengoli_y_b), 1
-    )
+    const.soilm_mengoli_y_a * np.power(aridity_index, const.soilm_mengoli_y_b), 1
+)
 
 
 psi = np.minimum(
@@ -251,8 +251,8 @@ psi = np.minimum(
     1,
 )
 
-plt.plot(aridity_index, y, label='Maximum level ($y$)')
-plt.plot(aridity_index, psi, label='Critical threshold ($\psi$)')
+plt.plot(aridity_index, y, label="Maximum level ($y$)")
+plt.plot(aridity_index, psi, label="Critical threshold ($\psi$)")
 plt.xlabel(r"Aridity Index (AI)")
 plt.ylabel(r"$\beta(\theta)$")
 plt.legend()
@@ -270,7 +270,7 @@ $$
     \end{cases}
 $$
 
-```{code-cell} ipython3
+```{code-cell}
 # Calculate the soil moisture stress factor across a soil moisture
 # gradient for different aridity index values
 beta = {}
@@ -280,7 +280,7 @@ for ai in ai_vals:
     beta[ai] = pmodel.calc_soilmstress_mengoli(
         soilm=sm_gradient, aridity_index=np.array(ai)
     )
-    plt.plot(sm_gradient, beta[ai], label= f"AI = {ai}")
+    plt.plot(sm_gradient, beta[ai], label=f"AI = {ai}")
 
 plt.xlabel(r"Relative soil moisture $\theta$")
 plt.ylabel(r"$\beta(\theta)$")
@@ -299,10 +299,10 @@ calculated and then applied to the GPP calculated for a model
 ({attr}`~pyrealm.pmodel.pmodel.PModel.gpp`). In the example below, the result is
 obviously just $\beta(\theta)$ from above scaled to the constant GPP.
 
-```{code-cell} ipython3
+```{code-cell}
 for ai in ai_vals:
 
-    plt.plot(sm_gradient, model.gpp * beta[ai], label= f"AI = {ai}")
+    plt.plot(sm_gradient, model.gpp * beta[ai], label=f"AI = {ai}")
 
 plt.xlabel(r"Relative soil moisture $\theta$")
 plt.ylabel("GPP")
@@ -310,6 +310,6 @@ plt.legend()
 plt.show()
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 
 ```

--- a/docs/source/users/pmodel/pmodel_details/worked_examples.md
+++ b/docs/source/users/pmodel/pmodel_details/worked_examples.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -39,7 +39,7 @@ The example shows the steps required using a single site with:
 
 ### Estimate photosynthetic environment
 
-```{code-cell} ipython3
+```{code-cell}
 from importlib import resources
 
 from matplotlib import pyplot as plt
@@ -59,11 +59,11 @@ terse - just the shape of the data - but the
 {meth}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment.summarize` method provides a
 more detailed summary of the attributes.
 
-```{code-cell} ipython3
+```{code-cell}
 env
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 env.summarize()
 ```
 
@@ -72,14 +72,14 @@ env.summarize()
 Next, the P Model can be fitted to the photosynthetic environment using the
 ({class}`~pyrealm.pmodel.pmodel.PModel`) class:
 
-```{code-cell} ipython3
+```{code-cell}
 model = PModel(env)
 ```
 
 The returned model object holds a lot of information. The representation of the
 model object shows a terse display of the settings used to run the model:
 
-```{code-cell} ipython3
+```{code-cell}
 model
 ```
 
@@ -89,7 +89,7 @@ displays a summary of calculated predictions. Initially, this shows two measures
 photosynthetic efficiency: the intrinsic water use efficiency (``iwue``) and the light
 use efficiency (``lue``).
 
-```{code-cell} ipython3
+```{code-cell}
 model.summarize()
 ```
 
@@ -101,7 +101,7 @@ recording key parameters from the [calculation of $\chi$](./optimal_chi).
 This object also has a {meth}`~pyrealm.pmodel.optimal_chi.OptimalChiABC.summarize`
 method:
 
-```{code-cell} ipython3
+```{code-cell}
 model.optchi.summarize()
 ```
 
@@ -117,7 +117,7 @@ Here we are using:
 * An absorption fraction of 0.91 (-), and
 * a PPFD of 834 µmol m-2 s-1.
 
-```{code-cell} ipython3
+```{code-cell}
 model.estimate_productivity(fapar=0.91, ppfd=834)
 model.summarize()
 ```
@@ -149,12 +149,12 @@ to be the same size so some of the variables have repeated data across dimension
   cell.
 * Elevation is constant across months, so the data for each month is repeated.
 
-```{code-cell} ipython3
+```{code-cell}
 # Load an example dataset containing the forcing variables.
-data_path = resources.files('pyrealm_build_data.rpmodel') / "pmodel_global.nc"
+data_path = resources.files("pyrealm_build_data.rpmodel") / "pmodel_global.nc"
 ds = xarray.load_dataset(data_path)
 
-# Extract the six variables for the two months and convert from 
+# Extract the six variables for the two months and convert from
 # xarray DataArray objects to numpy arrays
 temp = ds["temp"].to_numpy()
 co2 = ds["CO2"].to_numpy()
@@ -168,7 +168,7 @@ The model can now be run using that data. The first step is to convert the eleva
 data to atmospheric pressure, and then this is used to set the photosynthetic
 environment for the model:
 
-```{code-cell} ipython3
+```{code-cell}
 # Convert elevation to atmospheric pressure
 patm = calc_patm(elev)
 
@@ -186,24 +186,24 @@ env.summarize()
 That environment can then be run to calculate the P model predictions for light use
 efficiency:
 
-```{code-cell} ipython3
+```{code-cell}
 # Run the P model
 model = PModel(env)
 
 # Plot LUE for first month
 im = plt.imshow(model.lue[0, :, :], origin="lower", extent=[-180, 180, -90, 90])
 plt.colorbar(im, fraction=0.022, pad=0.03)
-plt.title("Light use efficiency");
+plt.title("Light use efficiency")
 ```
 
 Finally, the light use efficiency can be used to calculate GPP given the
 photosynthetic photon flux density and fAPAR.
 
-```{code-cell} ipython3
+```{code-cell}
 # Scale the outputs from values per unit iabs to realised values
 model.estimate_productivity(fapar, ppfd)
 
 im = plt.imshow(model.gpp[0, :, :], origin="lower", extent=[-180, 180, -90, 90])
 plt.colorbar(im, fraction=0.022, pad=0.03)
-plt.title("GPP");
+plt.title("GPP")
 ```

--- a/docs/source/users/pmodel/pmodel_details/worked_examples.md
+++ b/docs/source/users/pmodel/pmodel_details/worked_examples.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.8
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Worked examples

--- a/docs/source/users/pmodel/subdaily_details/acclimation.md
+++ b/docs/source/users/pmodel/subdaily_details/acclimation.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.8
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Estimating acclimation

--- a/docs/source/users/pmodel/subdaily_details/acclimation.md
+++ b/docs/source/users/pmodel/subdaily_details/acclimation.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -60,8 +60,6 @@ present results using one hour windows around noon or even the single value clos
 noon.
 
 ```{code-cell}
-:tags: []
-
 # Define a set of observations at a subdaily timescale
 fast_datetimes = np.arange(
     np.datetime64("1970-01-01"), np.datetime64("1970-01-08"), np.timedelta64(30, "m")

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.1
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Subdaily P Model calculations

--- a/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.1
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -47,7 +47,7 @@ The code below gives a concrete example - a time series that starts and ends dur
 the middle of a one hour acclimation window around noon. Only two of the three
 observations are provided for the first and last day
 
-```{code-cell} ipython3
+```{code-cell}
 import numpy as np
 
 from pyrealm.pmodel.scaler import SubdailyScaler
@@ -55,24 +55,25 @@ from pyrealm.pmodel.subdaily import memory_effect
 
 # A five day time series running from noon until noon
 datetimes = np.arange(
-    np.datetime64('2012-05-06 12:00'),
-    np.datetime64('2012-05-12 12:00'),
-    np.timedelta64(30, 'm')
+    np.datetime64("2012-05-06 12:00"),
+    np.datetime64("2012-05-12 12:00"),
+    np.timedelta64(30, "m"),
 )
 
 # Example data with missing values
-data = np.arange(len(datetimes), dtype='float')
-data[datetimes == np.datetime64('2012-05-08 11:30')] = np.nan
-data[np.logical_and(
-    datetimes >= np.datetime64('2012-05-10 11:30'),
-    datetimes <= np.datetime64('2012-05-10 12:30'),
-    )] = np.nan
+data = np.arange(len(datetimes), dtype="float")
+data[datetimes == np.datetime64("2012-05-08 11:30")] = np.nan
+data[
+    np.logical_and(
+        datetimes >= np.datetime64("2012-05-10 11:30"),
+        datetimes <= np.datetime64("2012-05-10 12:30"),
+    )
+] = np.nan
 
 # Create the acclimation window sampler
 fsscaler = SubdailyScaler(datetimes)
 fsscaler.set_window(
-    window_center = np.timedelta64(12, 'h'),
-    half_width = np.timedelta64(30, 'm')
+    window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(30, "m")
 )
 ```
 
@@ -88,7 +89,7 @@ problem of the missing data clearly:
 * One day has a single missing 12:00 data point within the acclimation window.
 * One day has no data within the acclimation window.
 
-```{code-cell} ipython3
+```{code-cell}
 fsscaler.get_window_values(data)
 ```
 
@@ -97,7 +98,7 @@ The daily average conditions are calculated using the
 partial data are not allowed - which is the default - the daily average conditions for
 all days with missing data is also missing (`np.nan`).
 
-```{code-cell} ipython3
+```{code-cell}
 partial_not_allowed = fsscaler.get_daily_means(data)
 partial_not_allowed
 ```
@@ -106,7 +107,7 @@ Setting `allow_partial_data = True` allows the daily average conditions to be ca
 from the partial available information. This does not solve the problem for the day with
 no data in the acclimation window, which still results in a missing value.
 
-```{code-cell} ipython3
+```{code-cell}
 partial_allowed = fsscaler.get_daily_means(data, allow_partial_data=True)
 partial_allowed
 ```
@@ -115,8 +116,8 @@ The :func:`~pyrealm.pmodel.subdaily.memory_effect` function is used to calculate
 realised values of a variable from the optimal values. By default, this function *will
 raise an error* when missing data are present:
 
-```{code-cell} ipython3
-:tags: ["raises-exception"]
+```{code-cell}
+:tags: [raises-exception]
 
 memory_effect(partial_not_allowed)
 ```
@@ -125,14 +126,14 @@ The `allow_holdover` option allows the function to be run - the value for the fi
 is still `np.nan` but the missing observations on day 3, 5 and 7 are filled by holding
 over the valid observations from the previous day.
 
-```{code-cell} ipython3
+```{code-cell}
 memory_effect(partial_not_allowed, allow_holdover=True)
 ```
 
 When the partial data is allowed, the `allow_holdover` is still required to fill the
 gap on day 5 by holding over the data from day 4.
 
-```{code-cell} ipython3
+```{code-cell}
 memory_effect(partial_allowed, allow_holdover=True)
 ```
 

--- a/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.1
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Missing data in the subdaily model

--- a/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -65,7 +65,7 @@ The implementation has the following steps:
 * The daily realised values are then
   [interpolated](acclimation.md#interpolation-of-realised-values-to-subdaily-timescales)
   back to the subdaily time scale.
-  
+
 * Optimal $\chi$ is then recalculated on the subdaily timescale, but with the values of
   $\xi$ constrained to the slowly responding realised values. Similarly, $V_{cmax}$ and
   $J_{max}$ are calculated estimated at the subdaily temperatures, but using the

--- a/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.8
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The P Model with acclimation

--- a/docs/source/users/pmodel/subdaily_details/worked_example.md
+++ b/docs/source/users/pmodel/subdaily_details/worked_example.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.1
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # Worked example of the Subdaily P Model

--- a/docs/source/users/splash.md
+++ b/docs/source/users/splash.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -47,7 +47,7 @@ The data below provides a 2 year daily time series of precipitation, temperature
 solar fraction (1 - cloud cover) for 0.5° resolution grid cells in a 10° by 10° block
 of the North Western USA. It also provides the mean elevation of those cells.
 
-```{code-cell} python
+```{code-cell}
 from importlib import resources
 import numpy as np
 import xarray
@@ -75,7 +75,7 @@ data
 The plot below shows the elevation for the example data area, along with the locations
 of three sites that will be used to compare SPLASH outputs.
 
-```{code-cell} python
+```{code-cell}
 # Get the latitude and longitude extents
 extent = (
     data["lon"].min(),
@@ -96,7 +96,7 @@ The three sites capture wetter coastal conditions with milder temperatures (San
 Francisco), intermediate rainfall with colder temperatures (Yosemite) and arid
 conditions with extreme temperatures (Death Valley).
 
-```{code-cell} python
+```{code-cell}
 # Get three sites to show time series for locations
 site_data = data.sel(sites, method="nearest")
 
@@ -150,7 +150,7 @@ may well be constant across the longitude dimension for gridded data - but, at t
 moment, you need to broadcast these variables to match.
 ```
 
-```{code-cell} python
+```{code-cell}
 splash = SplashModel(
     lat=np.broadcast_to(data.lat.data[None, :, None], data.sf.data.shape),
     elv=np.broadcast_to(data.elev.data[None, :, :], data.sf.data.shape),
@@ -177,7 +177,7 @@ give the expected soil moisture at the end of the year. If this is sufficiently 
 to the start values, the estimate is returned, otherwise the end of year expectations
 are used as a starting point to recalculate the annual water balances.
 
-```{code-cell} python
+```{code-cell}
 init_soil_moisture = splash.estimate_initial_soil_moisture(verbose=False)
 ```
 
@@ -201,7 +201,7 @@ The plots show the soil moisture for the first day, along with the changes in so
 moisture from the initial estimates (the 'previous day'). Note the saturated soil
 moisture of 150mm near the coast and in the mountains.
 
-```{code-cell} python
+```{code-cell}
 # Calculate the water balance equation for the first day from the initial soil
 #  moisture estimates.
 aet, wn, ro = splash.estimate_daily_water_balance(init_soil_moisture, day_idx=0)
@@ -224,13 +224,13 @@ the daily estimation across all of the dates in the input data from initial soil
 moisture estimates. It returns a set of time series of soil moisture, runoff and AET for
 all sites.
 
-```{code-cell} python
+```{code-cell}
 aet_out, wn_out, ro_out = splash.calculate_soil_moisture(init_soil_moisture)
 ```
 
 The plots below show the resulting soil moisture and a time series for the three
 
-```{code-cell} python
+```{code-cell}
 # Add the outputs to the xarray to select the three sites easily.
 data["aet"] = xarray.DataArray(aet_out, dims=("time", "lat", "lon"))
 data["wn"] = xarray.DataArray(wn_out, dims=("time", "lat", "lon"))

--- a/docs/source/users/splash.md
+++ b/docs/source/users/splash.md
@@ -7,9 +7,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.8
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The `splash` submodule

--- a/docs/source/users/tmodel/tmodel.md
+++ b/docs/source/users/tmodel/tmodel.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -32,9 +32,10 @@ class description.
 
 The class can be used to create a default T Model trait set:
 
-```{code-cell} ipython3
+```{code-cell}
 import numpy as np
 from pyrealm import tmodel
+
 # A tree using the default parameterisation
 traits1 = tmodel.TModelTraits()
 print(traits1)
@@ -42,7 +43,7 @@ print(traits1)
 
 It can also be edited to generate different growth patterns:
 
-```{code-cell} ipython3
+```{code-cell}
 # A slower growing tree with a higher maximum height
 traits2 = tmodel.TModelTraits(a_hd=50, h_max=40)
 print(traits2)
@@ -71,10 +72,10 @@ diameters and an optional set of traits as a
 {class}`~pyrealm.constants.tmodel_const.TModelTraits` object. If no traits are provided,
 the default {class}`~pyrealm.constants.tmodel_const.TModelTraits` settings are used.
 
-```{code-cell} ipython3
+```{code-cell}
 # Use a sequence of diameters from sapling to large tree
 diameters = np.linspace(0.02, 2, 100)
-tree1 = tmodel.TTree(diameters=diameters)  # Using default traits 
+tree1 = tmodel.TTree(diameters=diameters)  # Using default traits
 tree2 = tmodel.TTree(diameters=diameters, traits=traits2)
 ```
 
@@ -92,30 +93,31 @@ These inputs are then immediately used to calculate the following properties of 
 Using an array of diameter values provides an immediate way to visualise the geometric
 scaling resulting from a particular set of plant traits:
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 from matplotlib import pyplot
-fig, (ax1, ax2, ax3) = pyplot.subplots(1,3, figsize=(12, 4))
-ax1.plot(tree1.diameter, tree1.height, label='traits1')
-ax1.plot(tree2.diameter, tree2.height, label='traits2')
-ax1.set_title('Height')
-ax1.set_xlabel('Stem diameter (m)')
-ax1.set_ylabel('Height (m)')
+
+fig, (ax1, ax2, ax3) = pyplot.subplots(1, 3, figsize=(12, 4))
+ax1.plot(tree1.diameter, tree1.height, label="traits1")
+ax1.plot(tree2.diameter, tree2.height, label="traits2")
+ax1.set_title("Height")
+ax1.set_xlabel("Stem diameter (m)")
+ax1.set_ylabel("Height (m)")
 ax1.legend()
-ax2.plot(tree1.diameter, tree1.crown_area, label='traits1')
-ax2.plot(tree2.diameter, tree2.crown_area, label='traits2')
-ax2.set_title('Crown Area')
-ax2.set_xlabel('Stem diameter (m)')
-ax2.set_ylabel('Crown area (m2)')
+ax2.plot(tree1.diameter, tree1.crown_area, label="traits1")
+ax2.plot(tree2.diameter, tree2.crown_area, label="traits2")
+ax2.set_title("Crown Area")
+ax2.set_xlabel("Stem diameter (m)")
+ax2.set_ylabel("Crown area (m2)")
 ax2.legend()
-ax3.plot(tree1.diameter, tree1.mass_stm, label='Stem')
-ax3.plot(tree1.diameter, tree1.mass_swd, label='Sapwood')
-ax3.plot(tree1.diameter, tree1.mass_fol, label='Leaf and fine root')
-ax3.set_yscale('log')
-ax3.set_title('Mass (traits1)')
-ax3.set_xlabel('Stem diameter (m)')
-ax3.set_ylabel('Log Mass (kg)')
+ax3.plot(tree1.diameter, tree1.mass_stm, label="Stem")
+ax3.plot(tree1.diameter, tree1.mass_swd, label="Sapwood")
+ax3.plot(tree1.diameter, tree1.mass_fol, label="Leaf and fine root")
+ax3.set_yscale("log")
+ax3.set_title("Mass (traits1)")
+ax3.set_xlabel("Stem diameter (m)")
+ax3.set_ylabel("Log Mass (kg)")
 ax3.legend()
 pyplot.show()
 ```
@@ -143,33 +145,33 @@ provide estimates of the following growth parameters:
 The code below calculates growth estimates at each diameter under a constant GPP of 7
 TODO - UNITS!.
 
-```{code-cell} ipython3
+```{code-cell}
 tree1.calculate_growth(np.array([7]))
 tree2.calculate_growth(np.array([7]))
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
-fig, (ax1, ax2, ax3) = pyplot.subplots(1,3, figsize=(12, 4))
-ax1.plot(tree1.diameter, tree1.npp, label='traits1')
-ax1.plot(tree2.diameter, tree2.npp, label='traits2')
-ax1.set_title('NPP')
-ax1.set_xlabel('Net primary productivity (m)')
-ax1.set_ylabel('Height (m)')
+fig, (ax1, ax2, ax3) = pyplot.subplots(1, 3, figsize=(12, 4))
+ax1.plot(tree1.diameter, tree1.npp, label="traits1")
+ax1.plot(tree2.diameter, tree2.npp, label="traits2")
+ax1.set_title("NPP")
+ax1.set_xlabel("Net primary productivity (m)")
+ax1.set_ylabel("Height (m)")
 ax1.legend()
-ax2.plot(tree1.diameter, tree1.resp_swd, label='Sapwood')
-ax2.plot(tree1.diameter, tree1.resp_frt, label='Fine roots')
-ax2.plot(tree1.diameter, tree1.resp_fol, label='Foliage')
-ax2.set_title('Respiration (traits1)')
-ax2.set_xlabel('Stem diameter (m)')
-ax2.set_ylabel('Respiration')
+ax2.plot(tree1.diameter, tree1.resp_swd, label="Sapwood")
+ax2.plot(tree1.diameter, tree1.resp_frt, label="Fine roots")
+ax2.plot(tree1.diameter, tree1.resp_fol, label="Foliage")
+ax2.set_title("Respiration (traits1)")
+ax2.set_xlabel("Stem diameter (m)")
+ax2.set_ylabel("Respiration")
 ax2.legend()
-ax3.plot(tree1.diameter, tree1.delta_d, label='traits1')
-ax3.plot(tree2.diameter, tree2.delta_d, label='traits2')
-ax3.set_title('Delta diameter ')
-ax3.set_xlabel('Stem diameter (m)')
-ax3.set_ylabel('Delta diameter (m)')
+ax3.plot(tree1.diameter, tree1.delta_d, label="traits1")
+ax3.plot(tree2.diameter, tree2.delta_d, label="traits2")
+ax3.set_title("Delta diameter ")
+ax3.set_xlabel("Stem diameter (m)")
+ax3.set_ylabel("Delta diameter (m)")
 ax3.legend()
 pyplot.show()
 ```
@@ -182,12 +184,12 @@ The {meth}`~pyrealm.tmodel.TTree.reset_diameters` can be used to update an exist
 {meth}`~pyrealm.tmodel.TTree.reset_diameters` automatically resets any calculated growth
 parameters: they will need to be recalculated for the new diameters.
 
-```{code-cell} ipython3
+```{code-cell}
 tree1.reset_diameters(np.array([0.0001]))
 print(tree1.height)
 ```
 
-<!-- 
+<!--
 ## The {func}`~pyrealm.tmodel.grow_ttree` function
 
 The  {class}`~pyrealm.tmodel.TTree` class implements the calculation of the T Model

--- a/docs/source/users/tmodel/tmodel.md
+++ b/docs/source/users/tmodel/tmodel.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: pyrealm_python3
+  name: python3
 ---
 
 # The T Model


### PR DESCRIPTION
# Description

This removes the redundant step of creating a specific `pyrealm_python3` kernel for Jupyter notebooks and falls back on the `poetry shell` and `poetry run` commands updating the Jupyter kernel specs when run.

I have also added `jupytext --pipe black` as a `pre-commit` hook on the `docs/source` tree to add automatic `black` formatting of code cell contents, and also ensure consistent formatting of `{code-cell}` directives (omits the default language)

There is one downside of this, which is that `black` insists on stripping out semi-colons, which are a recognized (but hacky) way to suppress the printing of `matplotlib` function return values.

Fixes #246

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
