### PR TITLE
Allow P Models to accept an array of kphio values

### DIFF
--- a/docs/source/users/pmodel/pmodel_details/lue_limitation.md
+++ b/docs/source/users/pmodel/pmodel_details/lue_limitation.md
@@ -63,21 +63,6 @@ where $\phi_0$ is the quantum yield efficiency of photosynthesis, $M_C$ is the
 molar mass of carbon and $m_j$ is the $\ce{CO2}$ limitation term of light use
 efficiency from the calculation of optimal $\chi$.
 
-However, the {class}`pyrealm.pmodel.pmodel.PModel` class also incorporates two further
-factors:
-
-* temperature (t) dependence of $\phi_0$,
-* $J_{max}$ limitation of $m_j$ by a factor $f_v$ and
-
-$$
-  \text{LUE} = \phi_0(t) \cdot M_C \cdot m_j \cdot f_v$
-$$
-
-### $\phi_0$ and temperature dependency
-
-The {class}`~pyrealm.pmodel.pmodel.PModel` uses a single variable to capture the
-apparent quantum yield efficiency of photosynthesis (`kphio`, $\phi_0$).
-
 ```{warning}
 
 Note that $\phi_0$ is sometimes used to refer to the quantum yield of electron
@@ -86,7 +71,21 @@ photosynthesis.
 
 ```
 
-The value of $\phi_0$ shows temperature dependence, which is modelled following
+However, the {class}`pyrealm.pmodel.pmodel.PModel` class also incorporates two further
+factors:
+
+* temperature (t) dependence of $\phi_0$,
+* $J_{max}$ limitation of $m_j$ by a factor $f_v$ and
+
+$$
+  \text{LUE} = \phi_0(t) \cdot M_C \cdot m_j \cdot f_v
+$$
+
+### $\phi_0$ and temperature dependency
+
+The {class}`~pyrealm.pmodel.pmodel.PModel` uses a single variable to capture the
+apparent quantum yield efficiency of photosynthesis (`kphio`, $\phi_0$). The value of
+$\phi_0$ shows temperature dependence, which is modelled following
 {cite:t}`Bernacchi:2003dc` for C3 plants and {cite:t}`cai:2020a` for C4 plants (see
 {func}`~pyrealm.pmodel.functions.calc_ftemp_kphio`). The temperature dependency is
 applied by default but can be turned off using the
@@ -139,6 +138,42 @@ pyplot.title("Temperature dependence of quantum yield efficiency")
 pyplot.xlabel("Temperature °C")
 pyplot.ylabel("Limitation factor")
 pyplot.legend()
+pyplot.show()
+```
+
+### Setting $\phi_0$ directly
+
+In addition to fixed or temperature dependent $\phi_0$, it is also possible to provide
+$\phi_0$ values for each observation in the P Model. In this case, you will need to
+provide an array of values that has the same shape as the other driver variables and
+these values are then used within the calculations for each observation.
+
+This option is provided to allow users to experiment with alternative per-observation
+calculations of $\phi_0$ limitation - for example, modulation of $\phi_0$ by temperature
+and aridity - that are not implemented within the `PModel` or `SubdailyPModel` classes.
+This approach is used in the plot below to show the simple linear scaling of LUE with
+$\phi_0$ for a constant environment.
+
+```{code-cell}
+:tags: [hide-input]
+
+# A constant environment to show a range of kphio values
+kphio_values = np.arange(0, 0.126, step=0.001)
+n_vals = len(kphio_values)
+
+env = PModelEnvironment(
+    tc=np.repeat(20, n_vals),
+    patm=np.repeat(101325, n_vals),
+    vpd=np.repeat(820, n_vals),
+    co2=np.repeat(400, n_vals),
+)
+model_var_kphio = PModel(env, kphio=kphio_values, do_ftemp_kphio=False)
+
+# Create a line plot of ftemp kphio
+pyplot.plot(kphio_values, model_var_kphio.lue)
+pyplot.title("Variation in LUE with changing $\phi_0$")
+pyplot.xlabel("$\phi_0$")
+pyplot.ylabel("LUE")
 pyplot.show()
 ```
 

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -217,13 +217,13 @@ class PModel:
         # Set context specific defaults for kphio to match Stocker paper
         if kphio is None:
             if not self.do_ftemp_kphio:
-                self.init_kphio = np.array([0.049977])
+                self.init_kphio = np.array(0.049977)
             else:
-                self.init_kphio = np.array([0.081785])
+                self.init_kphio = np.array(0.081785)
         else:
             if isinstance(kphio, float):
                 # A single scalar global value
-                self.init_kphio = np.array([kphio])
+                self.init_kphio = np.array(kphio)
             elif isinstance(kphio, np.ndarray):
                 # An array of values, which must match the shape of the inputs to the
                 # PModelEnvironment instance.

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -186,7 +186,7 @@ class PModel:
     def __init__(
         self,
         env: PModelEnvironment,
-        kphio: float | None = None,
+        kphio: float | NDArray | None = None,
         do_ftemp_kphio: bool = True,
         method_optchi: str = "prentice14",
         method_jmaxlim: str = "wang17",
@@ -205,7 +205,7 @@ class PModel:
         """The CoreConst instance used to create the model environment."""
 
         # kphio calculation:
-        self.init_kphio: float
+        self.init_kphio: NDArray
         r"""The initial value of :math:`\phi_0` (``kphio``)"""
         self.kphio: NDArray
         r"""The value of :math:`\phi_0` used with any temperature correction applied."""
@@ -215,11 +215,18 @@ class PModel:
         # Set context specific defaults for kphio to match Stocker paper
         if kphio is None:
             if not self.do_ftemp_kphio:
-                self.init_kphio = 0.049977
+                self.init_kphio = np.array([0.049977])
             else:
-                self.init_kphio = 0.081785
+                self.init_kphio = np.array([0.081785])
         else:
-            self.init_kphio = kphio
+            if isinstance(kphio, float):
+                # A single scalar global value
+                self.init_kphio = np.array([kphio])
+            elif isinstance(kphio, np.ndarray):
+                # An array of values, which must match the shape of the inputs to the
+                # PModelEnvironment instance.
+                _ = check_input_shapes(self.env.tc, kphio)
+                self.init_kphio = kphio
 
         # -----------------------------------------------------------------------
         # Optimal ci
@@ -251,7 +258,7 @@ class PModel:
             )
             self.kphio = self.init_kphio * ftemp_kphio
         else:
-            self.kphio = np.array([self.init_kphio])
+            self.kphio = self.init_kphio
 
         # -----------------------------------------------------------------------
         # Calculation of Jmax limitation terms

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -145,7 +145,9 @@ class PModel:
         kphio: (Optional) The quantum yield efficiency of photosynthesis
             (:math:`\phi_0`, unitless). Note that :math:`\phi_0` is sometimes used to
             refer to the quantum yield of electron transfer, which is exactly four times
-            larger, so check definitions here.
+            larger, so check definitions here. This is often a single global value, but
+            the argument also accepts externally calculated per-observation estimates of
+            kphio.
         method_optchi: (Optional, default=`prentice14`) Selects the method to be
             used for calculating optimal :math:`chi`. The choice of method also sets the
             choice of  C3 or C4 photosynthetic pathway (see

--- a/pyrealm/pmodel/subdaily.py
+++ b/pyrealm/pmodel/subdaily.py
@@ -211,7 +211,11 @@ class SubdailyPModel:
           function be allowed to hold over values to fill missing values.
         allow_partial_data: Should estimates of daily optimal conditions be calculated
           with missing values in the acclimation window.
-        kphio: The quantum yield efficiency of photosynthesis (:math:`\phi_0`, -).
+        kphio: The quantum yield efficiency of photosynthesis (:math:`\phi_0`, -). Note
+            that :math:`\phi_0` is sometimes used to refer to the quantum yield of
+            electron transfer, which is exactly four times larger, so check definitions
+            here. This is often a single global value, but the argument also accepts
+            externally calculated per-observation estimates of kphio.
         fill_kind: The approach used to fill daily realised values to the subdaily
           timescale, currently one of 'previous' or 'linear'.
     """

--- a/pyrealm/pmodel/subdaily.py
+++ b/pyrealm/pmodel/subdaily.py
@@ -181,6 +181,12 @@ class SubdailyPModel:
       :math:`\xi` but subdaily values in the other parameters.
     * Predictions of GPP are then made as in the standard P Model.
 
+    As with the :class:`~pyrealm.pmodel.pmodel.PModel`, the values of the `kphio`
+    argument _can_ be provided as an array of values, potentially varying through time
+    and space. The behaviour of the daily model that drives acclimation here is to take
+    the daily mean `kphio` value for each time series within the acclimation window, as
+    for the other variables. This is an experimental solution!
+
     Missing values:
 
         Missing data can arise in a number of ways: actual gaps in the forcing data, the

--- a/pyrealm/pmodel/subdaily.py
+++ b/pyrealm/pmodel/subdaily.py
@@ -272,7 +272,7 @@ class SubdailyPModel:
         # Setup initial kphio
         if isinstance(kphio, float):
             # A single scalar global value
-            self.init_kphio = np.array([kphio])
+            self.init_kphio = np.array(kphio)
         elif isinstance(kphio, np.ndarray):
             # An array of values, which must match the shape of the inputs to the
             # PModelEnvironment instance.
@@ -306,9 +306,19 @@ class SubdailyPModel:
 
         # 2) Fit a PModel to those environmental conditions, using the supplied settings
         #    for the original model.
+
+        # If the kphio is a non-scalar array, use the mean kphio within the window to
+        # calculate the daily optimal behaviour.
+        if np.ndim(self.init_kphio) > 0:
+            daily_kphio = fs_scaler.get_daily_means(
+                self.init_kphio, allow_partial_data=allow_partial_data
+            )
+        else:
+            daily_kphio = self.init_kphio
+
         self.pmodel_acclim: PModel = PModel(
             pmodel_env_acclim,
-            kphio=kphio,
+            kphio=daily_kphio,
             do_ftemp_kphio=do_ftemp_kphio,
             method_optchi=method_optchi,
             method_jmaxlim=method_jmaxlim,

--- a/tests/unit/pmodel/conftest.py
+++ b/tests/unit/pmodel/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixture definitions for the PModel unit test suite."""
+
+from importlib import resources
+
+import pandas
+import pytest
+
+
+@pytest.fixture(scope="module")
+def be_vie_data():
+    """Import the subdaily model benchmark test data."""
+
+    # Load the BE-Vie data
+    data_path = (
+        resources.files("pyrealm_build_data.subdaily") / "subdaily_BE_Vie_2014.csv"
+    )
+
+    data = pandas.read_csv(str(data_path))
+    data["time"] = pandas.to_datetime(data["time"])
+
+    return data

--- a/tests/unit/pmodel/conftest.py
+++ b/tests/unit/pmodel/conftest.py
@@ -1,7 +1,9 @@
 """Shared fixture definitions for the PModel unit test suite."""
 
+import datetime
 from importlib import resources
 
+import numpy as np
 import pandas
 import pytest
 
@@ -19,3 +21,88 @@ def be_vie_data():
     data["time"] = pandas.to_datetime(data["time"])
 
     return data
+
+
+@pytest.fixture(scope="function")
+def be_vie_data_components(be_vie_data):
+    """Provides a data factory to convert the test data into a PModelEnv and arrays.
+
+    This fixture returns an instance of a DataFactory class, that provides a `get`
+    method to allow different subsets of the data to be built into the inputs for
+    subdaily model testing. Providing this as a DataFactory generator allows tests to
+    access more than one subset of the same data, which is useful in comparing the
+    behaviour of complete and incomplete daily datetime sequences.
+
+    The get method supports two modes, "pad" and "crop, both of which also require a
+    `start` and `end` value.
+
+    * In "pad" mode,  the original time series is extended by the specified number of
+      half hourly steps at the start and end of the original data. The datetimes are
+      filled in to give an actual time series but the data values are simply padded with
+      `np.nan`. This is used to check that the presence of incomplete days does not
+      affect the prediction of the sequence of GPP values. Since the actual data are not
+      changed, the padded data should pass without affecting the calculations.
+
+    * In "crop" mode, the original time series is cropped to only the rows in start:end.
+      This is used to assess the behaviour of incomplete day handling and the switch
+      points between providing daily estimates.
+    """
+
+    from pyrealm.pmodel import PModelEnvironment
+
+    class DataFactory:
+        def get(
+            self,
+            mode: str = "",
+            start: int = 0,
+            end: int = 0,
+            pre_average: list[datetime.time] | None = None,
+        ):
+            # Get a copy of the data so as to not break the module scope loaded object.
+            data = be_vie_data.copy()
+
+            # Implement the two sampling modes
+            if mode == "pad":
+                # Get the new time series with the padded times
+                datetime_subdaily = data["time"].to_numpy()
+                spacing = np.diff(datetime_subdaily)[0]
+                pad_start = datetime_subdaily[0] - np.arange(start, 0, -1) * spacing
+                pad_end = datetime_subdaily[-1] + np.arange(1, end + 1, 1) * spacing
+
+                # Pad the data frame with np.nan as requested
+                data.index = range(start, len(data) + start)
+                data = data.reindex(range(0, len(data) + start + end))
+
+                # Set the new times into the data frame
+                data["time"] = np.concatenate([pad_start, datetime_subdaily, pad_end])
+
+            if mode == "crop":
+                # Crop the data to the requested block
+                data = data.iloc[start:end]
+
+            datetime_subdaily = data["time"].to_numpy()
+            ppfd_subdaily = data["ppfd"].to_numpy()
+            fapar_subdaily = data["fapar"].to_numpy()
+            expected_gpp = data["GPP_JAMES"].to_numpy()
+
+            # Create the environment including some randomly distributed water variables
+            # to test the methods that require those variables
+            rng = np.random.default_rng()
+            subdaily_env = PModelEnvironment(
+                tc=data["ta"].to_numpy(),
+                vpd=data["vpd"].to_numpy(),
+                co2=data["co2"].to_numpy(),
+                patm=data["patm"].to_numpy(),
+                theta=rng.uniform(low=0.5, high=0.8, size=ppfd_subdaily.shape),
+                rootzonestress=rng.uniform(low=0.7, high=1.0, size=ppfd_subdaily.shape),
+            )
+
+            return (
+                subdaily_env,
+                ppfd_subdaily,
+                fapar_subdaily,
+                datetime_subdaily,
+                expected_gpp,
+            )
+
+    return DataFactory()

--- a/tests/unit/pmodel/test_kphio_inputs.py
+++ b/tests/unit/pmodel/test_kphio_inputs.py
@@ -1,0 +1,99 @@
+"""Test kphio inputs to PModel.
+
+These tests check that the behaviour of the array kphio input options work as
+expected. The input values here are the simple scalar inputs to the rpmodel regression
+tests.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def basic_inputs_and_expected():
+    """Provides some simple test values and expectations."""
+    return (
+        SimpleNamespace(
+            tc=np.array([20]),
+            patm=np.array([101325]),
+            co2=np.array([400]),
+            vpd=np.array([1000]),
+            fapar=np.array([1]),
+            ppfd=np.array([300]),
+        ),
+        SimpleNamespace(
+            gpp=np.array([71.2246803]),
+            chi=np.array([0.69435201]),
+            vcmax=np.array([17.75034477]),
+            jmax=np.array([40.03293277]),
+        ),
+    )
+
+
+def test_scalar_kphio(basic_inputs_and_expected):
+    """Test that the basic test inputs give the correct answer."""
+
+    from pyrealm.pmodel import PModel, PModelEnvironment
+
+    inputs, expected = basic_inputs_and_expected
+
+    env = PModelEnvironment(
+        tc=inputs.tc, patm=inputs.patm, co2=inputs.co2, vpd=inputs.vpd
+    )
+    mod = PModel(env, kphio=0.05, do_ftemp_kphio=False)
+    mod.estimate_productivity(fapar=inputs.fapar, ppfd=inputs.ppfd)
+
+    assert np.allclose(mod.gpp, expected.gpp)
+    assert np.allclose(mod.optchi.chi, expected.chi)
+    assert np.allclose(mod.jmax, expected.jmax)
+    assert np.allclose(mod.vcmax, expected.vcmax)
+
+
+@pytest.fixture
+def variable_kphio(self, basic_inputs_and_expected):
+    """Calculates gpp with alternate kphio by iteration.
+
+    This uses the original single scalar value approach (tested above) to get
+    expected values for a wide range of kphio values by iteration.
+    """
+
+    from pyrealm.pmodel import PModel, PModelEnvironment
+
+    inputs, _ = basic_inputs_and_expected
+
+    # Set a large range of values to use in testing
+    kphio_values = np.arange(0.001, 0.126, step=0.001)
+    gpp = np.empty_like(kphio_values)
+
+    for idx, kph in enumerate(kphio_values):
+        env = PModelEnvironment(
+            tc=inputs.tc, patm=inputs.patm, co2=inputs.co2, vpd=inputs.vpd
+        )
+        mod = PModel(env, kphio=kph, do_ftemp_kphio=False)
+        mod.estimate_productivity(fapar=inputs.fapar, ppfd=inputs.ppfd)
+        gpp[idx] = mod.gpp
+
+    return kphio_values, gpp
+
+
+@pytest.mark.parametrize(argnames="shape", argvalues=[(125,), (25, 5), (5, 5, 5)])
+def test_kphio_arrays(self, basic_inputs_and_expected, variable_kphio, shape):
+    """Check behaviour with array inputs of kphio."""
+
+    from pyrealm.pmodel import PModel, PModelEnvironment
+
+    inputs, _ = basic_inputs_and_expected
+    kphio_vals, expected_gpp = variable_kphio
+
+    env = PModelEnvironment(
+        tc=np.broadcast_to(inputs.tc, shape),
+        patm=np.broadcast_to(inputs.patm, shape),
+        co2=np.broadcast_to(inputs.co2, shape),
+        vpd=np.broadcast_to(inputs.vpd, shape),
+    )
+    mod = PModel(env, kphio=kphio_vals.reshape(shape), do_ftemp_kphio=False)
+    mod.estimate_productivity(fapar=inputs.fapar, ppfd=inputs.ppfd)
+
+    assert np.allclose(mod.gpp, expected_gpp.reshape(shape))

--- a/tests/unit/pmodel/test_subdaily.py
+++ b/tests/unit/pmodel/test_subdaily.py
@@ -2,28 +2,11 @@
 
 import datetime
 from contextlib import nullcontext as does_not_raise
-from importlib import resources
 
 import numpy as np
-import pandas
 import pytest
 
 from pyrealm.pmodel.optimal_chi import OPTIMAL_CHI_CLASS_REGISTRY
-
-
-@pytest.fixture(scope="module")
-def be_vie_data():
-    """Import the benchmark test data."""
-
-    # Load the BE-Vie data
-    data_path = (
-        resources.files("pyrealm_build_data.subdaily") / "subdaily_BE_Vie_2014.csv"
-    )
-
-    data = pandas.read_csv(str(data_path))
-    data["time"] = pandas.to_datetime(data["time"])
-
-    return data
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/pmodel/test_subdaily.py
+++ b/tests/unit/pmodel/test_subdaily.py
@@ -1,97 +1,11 @@
 """Tests the implementation of the FastSlowModel against the reference benchmark."""
 
-import datetime
 from contextlib import nullcontext as does_not_raise
 
 import numpy as np
 import pytest
 
 from pyrealm.pmodel.optimal_chi import OPTIMAL_CHI_CLASS_REGISTRY
-
-
-@pytest.fixture(scope="function")
-def be_vie_data_components(be_vie_data):
-    """Provides a data factory to convert the test data into a PModelEnv and arrays.
-
-    This fixture returns an instance of a DataFactory class, that provides a `get`
-    method to allow different subsets of the data to be built into the inputs for
-    subdaily model testing. Providing this as a DataFactory generator allows tests to
-    access more than one subset of the same data, which is useful in comparing the
-    behaviour of complete and incomplete daily datetime sequences.
-
-    The get method supports two modes, "pad" and "crop, both of which also require a
-    `start` and `end` value.
-
-    * In "pad" mode,  the original time series is extended by the specified number of
-      half hourly steps at the start and end of the original data. The datetimes are
-      filled in to give an actual time series but the data values are simply padded with
-      `np.nan`. This is used to check that the presence of incomplete days does not
-      affect the prediction of the sequence of GPP values. Since the actual data are not
-      changed, the padded data should pass without affecting the calculations.
-
-    * In "crop" mode, the original time series is cropped to only the rows in start:end.
-      This is used to assess the behaviour of incomplete day handling and the switch
-      points between providing daily estimates.
-    """
-
-    from pyrealm.pmodel import PModelEnvironment
-
-    class DataFactory:
-        def get(
-            self,
-            mode: str = "",
-            start: int = 0,
-            end: int = 0,
-            pre_average: list[datetime.time] | None = None,
-        ):
-            # Get a copy of the data so as to not break the module scope loaded object.
-            data = be_vie_data.copy()
-
-            # Implement the two sampling modes
-            if mode == "pad":
-                # Get the new time series with the padded times
-                datetime_subdaily = data["time"].to_numpy()
-                spacing = np.diff(datetime_subdaily)[0]
-                pad_start = datetime_subdaily[0] - np.arange(start, 0, -1) * spacing
-                pad_end = datetime_subdaily[-1] + np.arange(1, end + 1, 1) * spacing
-
-                # Pad the data frame with np.nan as requested
-                data.index = range(start, len(data) + start)
-                data = data.reindex(range(0, len(data) + start + end))
-
-                # Set the new times into the data frame
-                data["time"] = np.concatenate([pad_start, datetime_subdaily, pad_end])
-
-            if mode == "crop":
-                # Crop the data to the requested block
-                data = data.iloc[start:end]
-
-            datetime_subdaily = data["time"].to_numpy()
-            ppfd_subdaily = data["ppfd"].to_numpy()
-            fapar_subdaily = data["fapar"].to_numpy()
-            expected_gpp = data["GPP_JAMES"].to_numpy()
-
-            # Create the environment including some randomly distributed water variables
-            # to test the methods that require those variables
-            rng = np.random.default_rng()
-            subdaily_env = PModelEnvironment(
-                tc=data["ta"].to_numpy(),
-                vpd=data["vpd"].to_numpy(),
-                co2=data["co2"].to_numpy(),
-                patm=data["patm"].to_numpy(),
-                theta=rng.uniform(low=0.5, high=0.8, size=ppfd_subdaily.shape),
-                rootzonestress=rng.uniform(low=0.7, high=1.0, size=ppfd_subdaily.shape),
-            )
-
-            return (
-                subdaily_env,
-                ppfd_subdaily,
-                fapar_subdaily,
-                datetime_subdaily,
-                expected_gpp,
-            )
-
-    return DataFactory()
 
 
 def test_SubdailyPModel_JAMES(be_vie_data_components):


### PR DESCRIPTION
# Description

This PR update the `kphio` arguments to `PModel` and `SubdailyPModel` to accept an array of `kphio` estimates. This is largely intended to allow users to test alternative models for calculating `kphio` - there is an approach that accounts for temperature and soil moisture being developed.

The PR then includes a new test suite for this feature that checks that outcomes of passing in an array of kphio values is identical to the predictions of calculating those values using a single value at a time, and that the results are not sensitive to the shape of the inputs. That is repeated for `PModel` and `SubdailyPModel`.

Fixes #261

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
