### PR TITLE
Add StemAllometry class

### DIFF
--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -79,10 +79,10 @@ class Canopy:
         # Calculate community wide properties: total crown area, maximum height, crown
         # area required to fill a layer and total number of canopy layers
         self.total_community_crown_area = (
-            community.cohort_data["crown_area"] * community.cohort_data["n_individuals"]
+            community.stem_allometry.crown_area * community.cohort_data["n_individuals"]
         ).sum()
 
-        self.max_stem_height = community.cohort_data["stem_height"].max()
+        self.max_stem_height = community.stem_allometry.stem_height.max()
 
         self.crown_area_per_layer = community.cell_area * (1 - self.canopy_gap_fraction)
 
@@ -109,12 +109,12 @@ class Canopy:
             solution = root_scalar(
                 solve_community_projected_canopy_area,
                 args=(
-                    community.cohort_data["stem_height"],
-                    community.cohort_data["crown_area"],
+                    community.stem_allometry.stem_height,
+                    community.stem_allometry.crown_area,
                     community.stem_traits.m,
                     community.stem_traits.n,
                     community.stem_traits.q_m,
-                    community.cohort_data["canopy_z_max"],
+                    community.stem_allometry.canopy_z_max,
                     community.cohort_data["n_individuals"],
                     target_area,
                     False,  # validate
@@ -136,7 +136,7 @@ class Canopy:
         # turning off the validation internally should simply speed up the code.
         self.stem_relative_radius = calculate_relative_canopy_radius_at_z(
             z=self.layer_heights,
-            stem_height=community.cohort_data["stem_height"],
+            stem_height=community.stem_allometry.stem_height,
             m=community.stem_traits.m,
             n=community.stem_traits.n,
             validate=False,
@@ -146,10 +146,10 @@ class Canopy:
         self.stem_crown_area = calculate_stem_projected_crown_area_at_z(
             z=self.layer_heights,
             q_z=self.stem_relative_radius,
-            crown_area=community.cohort_data["crown_area"],
-            stem_height=community.cohort_data["stem_height"],
+            crown_area=community.stem_allometry.crown_area,
+            stem_height=community.stem_allometry.stem_height,
             q_m=community.stem_traits.q_m,
-            z_max=community.cohort_data["canopy_z_max"],
+            z_max=community.stem_allometry.canopy_z_max,
             validate=False,
         )
 
@@ -157,10 +157,10 @@ class Canopy:
         self.stem_leaf_area = calculate_stem_projected_leaf_area_at_z(
             z=self.layer_heights,
             q_z=self.stem_relative_radius,
-            crown_area=community.cohort_data["crown_area"],
-            stem_height=community.cohort_data["stem_height"],
+            crown_area=community.stem_allometry.crown_area,
+            stem_height=community.stem_allometry.stem_height,
             f_g=community.stem_traits.f_g,
             q_m=community.stem_traits.q_m,
-            z_max=community.cohort_data["canopy_z_max"],
+            z_max=community.stem_allometry.canopy_z_max,
             validate=False,
         )

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -117,9 +117,8 @@ from marshmallow.exceptions import ValidationError
 from numpy.typing import NDArray
 
 from pyrealm.core.utilities import check_input_shapes
-from pyrealm.demography import canopy_functions
-from pyrealm.demography import t_model_functions as t_model
 from pyrealm.demography.flora import Flora, StemTraits
+from pyrealm.demography.t_model_functions import StemAllometry
 
 if sys.version_info[:2] >= (3, 11):
     import tomllib
@@ -356,6 +355,7 @@ class Community:
     # Post init properties
     number_of_cohorts: int = field(init=False)
     stem_traits: StemTraits = field(init=False)
+    stem_allometry: StemAllometry = field(init=False)
     cohort_data: dict[str, NDArray] = field(init=False)
 
     def __post_init__(
@@ -405,66 +405,9 @@ class Community:
 
         self.number_of_cohorts = len(cohort_pft_names)
 
-        # Populate the T model fields
-        self._calculate_t_model()
-
-    def _calculate_t_model(self) -> None:
-        """Calculate T Model predictions across cohort data.
-
-        This method populates or updates the community attributes predicted by the T
-        Model :cite:`Li:2014bc` and by the canopy shape extensions to the T Model
-        implemented in PlantFate :cite:`joshi:2022a`.
-        """
-
-        # Add data to cohort dataframes capturing the T Model geometry
-        # - Classic T Model scaling
-        self.cohort_data["stem_height"] = t_model.calculate_heights(
-            h_max=self.stem_traits.h_max,
-            a_hd=self.stem_traits.a_hd,
-            dbh=self.cohort_data["dbh"],
-        )
-
-        self.cohort_data["crown_area"] = t_model.calculate_crown_areas(
-            ca_ratio=self.stem_traits.ca_ratio,
-            a_hd=self.stem_traits.a_hd,
-            dbh=self.cohort_data["dbh"],
-            stem_height=self.cohort_data["stem_height"],
-        )
-
-        self.cohort_data["crown_fraction"] = t_model.calculate_crown_fractions(
-            a_hd=self.stem_traits.a_hd,
-            dbh=self.cohort_data["dbh"],
-            stem_height=self.cohort_data["stem_height"],
-        )
-
-        self.cohort_data["stem_mass"] = t_model.calculate_stem_masses(
-            rho_s=self.stem_traits.rho_s,
-            dbh=self.cohort_data["dbh"],
-            stem_height=self.cohort_data["stem_height"],
-        )
-
-        self.cohort_data["foliage_mass"] = t_model.calculate_foliage_masses(
-            sla=self.stem_traits.sla,
-            lai=self.stem_traits.lai,
-            crown_area=self.cohort_data["crown_area"],
-        )
-
-        self.cohort_data["sapwood_mass"] = t_model.calculate_sapwood_masses(
-            rho_s=self.stem_traits.rho_s,
-            ca_ratio=self.stem_traits.ca_ratio,
-            stem_height=self.cohort_data["stem_height"],
-            crown_area=self.cohort_data["crown_area"],
-            crown_fraction=self.cohort_data["crown_fraction"],
-        )
-
-        # Canopy shape extension to T Model from PlantFATE
-        self.cohort_data["canopy_z_max"] = canopy_functions.calculate_canopy_z_max(
-            z_max_prop=self.stem_traits.z_max_prop,
-            stem_height=self.cohort_data["stem_height"],
-        )
-        self.cohort_data["canopy_r0"] = canopy_functions.calculate_canopy_r0(
-            q_m=self.stem_traits.q_m,
-            crown_area=self.cohort_data["crown_area"],
+        # Populate the stem allometry
+        self.stem_allometry = StemAllometry(
+            stem_traits=self.stem_traits, dbh=cohort_dbh_values
         )
 
     @classmethod

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -89,12 +89,17 @@ Initialize a Community into an area of 1000 square meter with the given cohort d
 ...     cohort_pft_names=cohort_pft_names
 ... )
 
-Convert the community cohort data to a :class:`pandas.DataFrame` for nicer display and
-show some of the calculated T Model predictions:
+Convert some of the data to a :class:`pandas.DataFrame` for nicer display and show some
+of the calculated T Model predictions:
 
->>> pd.DataFrame(community.cohort_data)[
-...    ['name', 'dbh', 'n_individuals', 'stem_height', 'crown_area', 'stem_mass']
-... ]
+>>> pd.DataFrame({
+...    'name': community.stem_traits.name,
+...    'n_individuals': community.cohort_data["n_individuals"],
+...    'dbh': community.stem_allometry.dbh,
+...    'stem_height': community.stem_allometry.stem_height,
+...    'crown_area': community.stem_allometry.crown_area,
+...    'stem_mass': community.stem_allometry.stem_mass,
+... })
               name    dbh  n_individuals  stem_height  crown_area  stem_mass
 0   Evergreen Tree  0.100            100     9.890399    2.459835   8.156296
 1  Deciduous Shrub  0.030            200     2.110534    0.174049   0.134266

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -94,8 +94,8 @@ of the calculated T Model predictions:
 
 >>> pd.DataFrame({
 ...    'name': community.stem_traits.name,
-...    'n_individuals': community.cohort_data["n_individuals"],
 ...    'dbh': community.stem_allometry.dbh,
+...    'n_individuals': community.cohort_data["n_individuals"],
 ...    'stem_height': community.stem_allometry.stem_height,
 ...    'crown_area': community.stem_allometry.crown_area,
 ...    'stem_mass': community.stem_allometry.stem_mass,
@@ -412,7 +412,7 @@ class Community:
 
         # Populate the stem allometry
         self.stem_allometry = StemAllometry(
-            stem_traits=self.stem_traits, dbh=cohort_dbh_values
+            stem_traits=self.stem_traits, at_dbh=cohort_dbh_values
         )
 
     @classmethod

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -621,16 +621,16 @@ class StemAllometry:
     Args:
         pft_data: A dictionary of plant functional trait data, as for example returned
             from :attr:`Flora.data<pyrealm.demography.flora.Flora.data>` attribute.
-        dbh: An array of diameter at breast height values for which to predict stem
+        at_dbh: An array of diameter at breast height values at which to predict stem
             allometry values.
     """
 
     # Init vars
     stem_traits: InitVar[Flora | StemTraits]
-    dbh: InitVar[NDArray[np.float32]]
+    at_dbh: InitVar[NDArray[np.float32]]
 
     # Post init allometry attributes
-    # dbh: NDArray[np.float32] = field(post_init=False)
+    dbh: NDArray[np.float32] = field(init=False)
     stem_height: NDArray[np.float32] = field(init=False)
     crown_area: NDArray[np.float32] = field(init=False)
     crown_fraction: NDArray[np.float32] = field(init=False)
@@ -641,35 +641,35 @@ class StemAllometry:
     canopy_z_max: NDArray[np.float32] = field(init=False)
 
     def __post_init__(
-        self, stem_traits: Flora | StemTraits, dbh: NDArray[np.float32]
+        self, stem_traits: Flora | StemTraits, at_dbh: NDArray[np.float32]
     ) -> None:
         """Populate the stem allometry attributes from the traits and size data."""
 
         self.stem_height = calculate_heights(
             h_max=stem_traits.h_max,
             a_hd=stem_traits.a_hd,
-            dbh=dbh,
+            dbh=at_dbh,
         )
 
-        # Broadcast dbh to shape of stem height to get congruent shapes
-        dbh = np.broadcast_to(dbh, self.stem_height.shape)
+        # Broadcast at_dbh to shape of stem height to get congruent shapes
+        self.dbh = np.broadcast_to(at_dbh, self.stem_height.shape)
 
         self.crown_area = calculate_crown_areas(
             ca_ratio=stem_traits.ca_ratio,
             a_hd=stem_traits.a_hd,
-            dbh=dbh,
+            dbh=self.dbh,
             stem_height=self.stem_height,
         )
 
         self.crown_fraction = calculate_crown_fractions(
             a_hd=stem_traits.a_hd,
-            dbh=dbh,
+            dbh=self.dbh,
             stem_height=self.stem_height,
         )
 
         self.stem_mass = calculate_stem_masses(
             rho_s=stem_traits.rho_s,
-            dbh=dbh,
+            dbh=self.dbh,
             stem_height=self.stem_height,
         )
 

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -620,8 +620,9 @@ class StemAllometry:
     traits.
 
     Args:
-        pft_data: A dictionary of plant functional trait data, as for example returned
-            from :attr:`Flora.data<pyrealm.demography.flora.Flora.data>` attribute.
+        stem_traits: An instance of :class:`~pyrealm.demography.flora.Flora` or
+            :class:`~pyrealm.demography.flora.StemTraits`, providing plant functional
+            trait data for a set of stems.
         at_dbh: An array of diameter at breast height values at which to predict stem
             allometry values.
     """
@@ -640,18 +641,32 @@ class StemAllometry:
 
     # Init vars
     stem_traits: InitVar[Flora | StemTraits]
+    """ An instance of :class:`~pyrealm.demography.flora.Flora` or 
+    :class:`~pyrealm.demography.flora.StemTraits`, providing plant functional trait data
+    for a set of stems."""
     at_dbh: InitVar[NDArray[np.float32]]
+    """An array of diameter at breast height values at which to predict stem allometry 
+    values."""
 
     # Post init allometry attributes
     dbh: NDArray[np.float32] = field(init=False)
+    """Diameter at breast height (metres)"""
     stem_height: NDArray[np.float32] = field(init=False)
+    """Stem height (metres)"""
     crown_area: NDArray[np.float32] = field(init=False)
+    """Crown area (square metres)"""
     crown_fraction: NDArray[np.float32] = field(init=False)
+    """Vertical fraction of the stem covered by the crown (-)"""
     stem_mass: NDArray[np.float32] = field(init=False)
+    """Stem mass (kg)"""
     foliage_mass: NDArray[np.float32] = field(init=False)
+    """Foliage mass (kg)"""
     sapwood_mass: NDArray[np.float32] = field(init=False)
+    """Sapwood mass (kg)"""
     canopy_r0: NDArray[np.float32] = field(init=False)
+    """Canopy radius scaling factor (-)"""
     canopy_z_max: NDArray[np.float32] = field(init=False)
+    """Height of maximum crown radius (metres)"""
 
     def __post_init__(
         self, stem_traits: Flora | StemTraits, at_dbh: NDArray[np.float32]

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -6,6 +6,7 @@ calculate stem growth given net primary productivity.
 """  # noqa: D205
 
 from dataclasses import InitVar, dataclass, field
+from typing import ClassVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -624,6 +625,18 @@ class StemAllometry:
         at_dbh: An array of diameter at breast height values at which to predict stem
             allometry values.
     """
+
+    allometry_attrs: ClassVar[tuple[str, ...]] = (
+        "dbh",
+        "stem_height",
+        "crown_area",
+        "crown_fraction",
+        "stem_mass",
+        "foliage_mass",
+        "sapwood_mass",
+        "canopy_r0",
+        "canopy_z_max",
+    )
 
     # Init vars
     stem_traits: InitVar[Flora | StemTraits]

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -38,7 +38,7 @@ def test_Canopy__init__():
         np.ceil(
             (
                 (
-                    community.cohort_data["crown_area"]
+                    community.stem_allometry.crown_area
                     * community.cohort_data["n_individuals"]
                 ).sum()
                 * (1 + canopy_gap_fraction)

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -42,7 +42,7 @@ def check_expected(community, expected):
         expected["a_hd"],
     )
     assert np.allclose(
-        community.cohort_data["stem_height"],
+        community.stem_allometry.stem_height,
         expected["height"],
     )
 

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -704,3 +704,18 @@ def test_calculate_dbh_from_height_edge_cases():
 
     # Undefined entries
     assert np.all(np.isnan(dbh) == np.array([[0, 0], [0, 0], [0, 0], [1, 0], [1, 1]]))
+
+
+def test_StemAllometry(rtmodel_flora, rtmodel_data):
+    """Test the StemAllometry class."""
+
+    from pyrealm.demography.t_model_functions import StemAllometry
+
+    stem_allometry = StemAllometry(
+        stem_traits=rtmodel_flora, at_dbh=rtmodel_data["dbh"][:, [0]]
+    )
+
+    # Check the variables provided by the rtmodel implementation
+    to_check = set(stem_allometry.allometry_attrs) - set(["canopy_r0", "canopy_z_max"])
+    for var in to_check:
+        assert np.allclose(getattr(stem_allometry, var), rtmodel_data[var])


### PR DESCRIPTION
# Description

This PR introduces the `demography.t_model_functions` StemAllometry class. This bundles the allometric equations into a higher level wrapper that takes a `Flora | StemTraits` instance and a set of stem sizes as DBH.

This new class then replaces the existing `Community._calculate_t_model` method and all of the rest of the existing code is updated to access stem allometry data through the class attributes. It also adds a simple test to confirm that the bundled allometry calculations still agree with the expected values tested on the individual functions.

Fixes #305

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
