### PR TITLE
Add user docs demonstrating demography traits and crown properties

### DIFF
--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -34,6 +34,7 @@ subtrees:
         - file: users/demography/flora.md
         - file: users/demography/t_model.md
         - file: users/demography/crown.md
+        - file: users/demography/community.md
         - file: users/demography/canopy.md
   - file: users/tmodel/tmodel.md
   - file: users/tmodel/canopy.md

--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -32,7 +32,9 @@ subtrees:
     subtrees:
       - entries:
         - file: users/demography/flora.md
+        - file: users/demography/t_model.md
         - file: users/demography/crown.md
+        - file: users/demography/canopy.md
   - file: users/tmodel/tmodel.md
   - file: users/tmodel/canopy.md
   - file: users/splash.md

--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -1,6 +1,7 @@
 root: index
 subtrees:
 
+
 - caption: Users
   entries: 
   - file: users/pmodel/module_overview.md
@@ -27,6 +28,11 @@ subtrees:
               - file: users/pmodel/subdaily_details/worked_example.md
         - file: users/pmodel/c3c4model.md
         - file: users/pmodel/isotopic_discrimination.md
+  - file: users/demography/module_overview.md
+    subtrees:
+      - entries:
+        - file: users/demography/flora.md
+        - file: users/demography/crown.md
   - file: users/tmodel/tmodel.md
   - file: users/tmodel/canopy.md
   - file: users/splash.md

--- a/docs/source/api/demography_api.md
+++ b/docs/source/api/demography_api.md
@@ -27,18 +27,26 @@ kernelspec:
     :members:
 ```
 
-## The {mod}`~pyrealm.demography.community` module
-
-```{eval-rst}
-.. automodule:: pyrealm.demography.community
-    :autosummary:
-    :members:
-```
-
 ## The {mod}`~pyrealm.demography.t_model_functions` module
 
 ```{eval-rst}
 .. automodule:: pyrealm.demography.t_model_functions
+    :autosummary:
+    :members:
+```
+
+## The {mod}`~pyrealm.demography.crown` module
+
+```{eval-rst}
+.. automodule:: pyrealm.demography.crown
+    :autosummary:
+    :members:
+```
+
+## The {mod}`~pyrealm.demography.community` module
+
+```{eval-rst}
+.. automodule:: pyrealm.demography.community
     :autosummary:
     :members:
 ```

--- a/docs/source/api/demography_api.md
+++ b/docs/source/api/demography_api.md
@@ -50,3 +50,11 @@ kernelspec:
     :autosummary:
     :members:
 ```
+
+## The {mod}`~pyrealm.demography.canopy` module
+
+```{eval-rst}
+.. automodule:: pyrealm.demography.canopy
+    :autosummary:
+    :members:
+```

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -82,22 +82,6 @@
   file = {/Users/dorme/Zotero/storage/EN33QA2H/J Math Chem 2009 Berberan-Santos.pdf}
 }
 
-@article{berger:1993a,
-  title = {Insolation and {{Earth}}'s Orbital Periods},
-  author = {Berger, Andr{\'e} and Loutre, Marie-France and Tricot, Christian},
-  year = {1993},
-  journal = {Journal of Geophysical Research: Atmospheres},
-  volume = {98},
-  number = {D6},
-  pages = {10341--10362},
-  issn = {2156-2202},
-  doi = {10.1029/93JD00222},
-  urldate = {2024-08-02},
-  abstract = {Solar irradiance received on a horizontal surface depends on the solar output, the semimajor axis of the elliptical orbit of the Earth around the sun (a), the distance from the Earth to the sun (r), and the zenith distance (z). The spectrum of the distance, r, for a given value of the true longitude, {$\lambda$}, displays mainly the precessional periods and, with much less power, half precession periods, eccentricity periods, and some combination tones. The zenith distance or its equivalent, the elevation angle (E), is only a function of obliquity ({$\epsilon$}) for a given latitude, {$\phi$}, true longitude, and hour angle, H. Therefore the insolation at a given constant value of z is only a function of precession and eccentricity. On the other hand, the value of the hour angle, H, corresponding to this fixed value of z varies with {$\varepsilon$}, except for the equinoxes, where H corresponding to a constant z also remains constant through time. Three kinds of insolation have been computed both analytically and numerically: the instantaneous insolation (irradiance) at noon, the daily irradiation, and the irradiations received during particular time intervals of the day defined by two constant values of the zenith distance (diurnal irradiations). Mean irradiances (irradiations divided by the length of the time interval over which they are calculated) are also computed for different time intervals, like the interval between sunrise and sunset, in particular. Examples of these insolations are given in this paper for the equinoxes and the solstices. At the equinoxes, for each latitude, all insolations are only a function of precession (this invalidates the results obtained by Cerveny [1991]). At the solstices, both precession and obliquity are present, although precession dominates for most of the latitudes. Because the lengths of the astronomical seasons are secularly variable (in terms of precession only), a particular calendar day does not always correspond to the same position relative to the sun through geological time. Similarly, a given longitude of the Sun on its orbit does not correspond to the same calendar day. For example, 103 kyr ago, assuming arbitrarily that the spring equinox is always on March 21, autumn began on September 13, and 114 kyr ago, it began on September 27, the length of the summer season being 85 and 98 calendar days, respectively, at these remote times in the past.},
-  langid = {english},
-  file = {/Users/dorme/Zotero/storage/ALTXDVSM/Berger et al. - 1993 - Insolation and Earth's orbital periods.pdf;/Users/dorme/Zotero/storage/HWQ4XSZN/93JD00222.html}
-}
-
 @article{berger:1978a,
   title = {Long-{{Term Variations}} of {{Daily Insolation}} and {{Quaternary Climatic Changes}}},
   author = {Berger, Andr{\'e}L},
@@ -115,6 +99,41 @@
   chapter = {Journal of the Atmospheric Sciences},
   langid = {english},
   file = {/Users/dorme/Zotero/storage/DPM5WN32/Berger - 1978 - Long-Term Variations of Daily Insolation and Quate.pdf}
+}
+
+@article{berger:1993a,
+  title = {Insolation and {{Earth}}'s Orbital Periods},
+  author = {Berger, Andr{\'e} and Loutre, Marie-France and Tricot, Christian},
+  year = {1993},
+  journal = {Journal of Geophysical Research: Atmospheres},
+  volume = {98},
+  number = {D6},
+  pages = {10341--10362},
+  issn = {2156-2202},
+  doi = {10.1029/93JD00222},
+  urldate = {2024-08-02},
+  abstract = {Solar irradiance received on a horizontal surface depends on the solar output, the semimajor axis of the elliptical orbit of the Earth around the sun (a), the distance from the Earth to the sun (r), and the zenith distance (z). The spectrum of the distance, r, for a given value of the true longitude, {$\lambda$}, displays mainly the precessional periods and, with much less power, half precession periods, eccentricity periods, and some combination tones. The zenith distance or its equivalent, the elevation angle (E), is only a function of obliquity ({$\epsilon$}) for a given latitude, {$\phi$}, true longitude, and hour angle, H. Therefore the insolation at a given constant value of z is only a function of precession and eccentricity. On the other hand, the value of the hour angle, H, corresponding to this fixed value of z varies with {$\varepsilon$}, except for the equinoxes, where H corresponding to a constant z also remains constant through time. Three kinds of insolation have been computed both analytically and numerically: the instantaneous insolation (irradiance) at noon, the daily irradiation, and the irradiations received during particular time intervals of the day defined by two constant values of the zenith distance (diurnal irradiations). Mean irradiances (irradiations divided by the length of the time interval over which they are calculated) are also computed for different time intervals, like the interval between sunrise and sunset, in particular. Examples of these insolations are given in this paper for the equinoxes and the solstices. At the equinoxes, for each latitude, all insolations are only a function of precession (this invalidates the results obtained by Cerveny [1991]). At the solstices, both precession and obliquity are present, although precession dominates for most of the latitudes. Because the lengths of the astronomical seasons are secularly variable (in terms of precession only), a particular calendar day does not always correspond to the same position relative to the sun through geological time. Similarly, a given longitude of the Sun on its orbit does not correspond to the same calendar day. For example, 103 kyr ago, assuming arbitrarily that the spring equinox is always on March 21, autumn began on September 13, and 114 kyr ago, it began on September 27, the length of the summer season being 85 and 98 calendar days, respectively, at these remote times in the past.},
+  langid = {english},
+  file = {/Users/dorme/Zotero/storage/ALTXDVSM/Berger et al. - 1993 - Insolation and Earth's orbital periods.pdf;/Users/dorme/Zotero/storage/HWQ4XSZN/93JD00222.html}
+}
+
+@article{Bernacchi:2001kg,
+  title = {Improved Temperature Response Functions for Models of {{Rubisco-limited}} Photosynthesis},
+  author = {Bernacchi, C J and Singsaas, E L and Pimentel, C and Portis Jr, A R and Long, S P},
+  year = {2001},
+  journal = {Plant, Cell \& Environment},
+  volume = {24},
+  number = {2},
+  pages = {253--259},
+  doi = {10.1111/j.1365-3040.2001.00668.x},
+  date-added = {2020-11-30T12:24:10GMT},
+  date-modified = {2020-11-30T14:42:53GMT},
+  langid = {english},
+  local-url = {file://localhost/Users/dorme/References/Library.papers3/Articles/2001/Bernacchi/Plant\%20Cell\%20\&\%20Environment\%202001\%20Bernacchi.pdf},
+  rating = {0},
+  read = {Yes},
+  uri = {papers3://publication/doi/10.1111/j.1365-3040.2001.00668.x},
+  file = {/Users/dorme/Zotero/storage/FI9562Z3/Plant Cell & Environment 2001 Bernacchi.pdf}
 }
 
 @article{Bernacchi:2003dc,
@@ -136,25 +155,6 @@
   rating = {0},
   uri = {papers3://publication/doi/10.1046/j.0016-8025.2003.01050.x},
   file = {/Users/dorme/Zotero/storage/7J2I98DM/Plant Cell & Environment 2003 Bernacchi.pdf}
-}
-
-@article{Bernacchi:2001kg,
-  title = {Improved Temperature Response Functions for Models of {{Rubisco-limited}} Photosynthesis},
-  author = {Bernacchi, C J and Singsaas, E L and Pimentel, C and Portis Jr, A R and Long, S P},
-  year = {2001},
-  journal = {Plant, Cell \& Environment},
-  volume = {24},
-  number = {2},
-  pages = {253--259},
-  doi = {10.1111/j.1365-3040.2001.00668.x},
-  date-added = {2020-11-30T12:24:10GMT},
-  date-modified = {2020-11-30T14:42:53GMT},
-  langid = {english},
-  local-url = {file://localhost/Users/dorme/References/Library.papers3/Articles/2001/Bernacchi/Plant\%20Cell\%20\&\%20Environment\%202001\%20Bernacchi.pdf},
-  rating = {0},
-  read = {Yes},
-  uri = {papers3://publication/doi/10.1111/j.1365-3040.2001.00668.x},
-  file = {/Users/dorme/Zotero/storage/FI9562Z3/Plant Cell & Environment 2001 Bernacchi.pdf}
 }
 
 @article{boyd:2015a,
@@ -247,6 +247,16 @@
   file = {/Users/dorme/Zotero/storage/8WDYDVKQ/Geoscientific Model Development 2015 De Kauwe.pdf;/Users/dorme/Zotero/storage/WXI7ASHC/Geoscientific Model Development 2015 De Kauwe.pdf}
 }
 
+@article{depury:1997a,
+  title = {Simple Scaling of Photosynthesis from Leaves to Canopies without the Errors of Big-Leaf Models},
+  author = {{de Pury}, G. D. D. and Farquhar, G D},
+  year = {1997},
+  journal = {Plant Cell and Environment},
+  number = {20},
+  pages = {537--557},
+  abstract = {In big-leaf models of canopy photosynthesis, the Rubisco activity per unit ground area is taken as the sum of activities per unit leaf area within the canopy, and electron transport capacity is similarly summed. Such models overestimate rates of photosynthesis and require empirical curvature factors in the response to irradiance. We show that, with any distribution of leaf nitrogen within the canopy (including optimal), the required curvature factors are not constant but vary with canopy leaf area index and leaf nitrogen content. We further show that the underlying reason is the difference between the time-averaged and instantaneous distributions of absorbed irradiance, caused by penetration of sunflecks and the range of leaf angles in canopies. These errors are avoided in models that treat the canopy in terms of a number of layers -- the multi-layer models. We present an alternative to the multi-layer model: by separately integrating the sunlit and shaded leaf fractions of the canopy, a single layered sun/shade model is obtained, which is as accurate and simpler. The model is a scaled version of a leaf model as distinct from an integrative approach.}
+}
+
 @article{Diaz:2016by,
   title = {The Global Spectrum of Plant Form and Function},
   author = {D{\'i}az, Sandra and Kattge, Jens and Cornelissen, Johannes H C and Wright, Ian J. and Lavorel, Sandra and Dray, St{\'e}phane and Reu, Bj{\"o}rn and Kleyer, Michael and Wirth, Christian and Prentice, I. Colin and Garnier, Eric and B{\"o}nisch, Gerhard and Westoby, Mark and Poorter, Hendrik and Reich, Peter B and Moles, Angela T and Dickie, John and Gillison, Andrew N and Zanne, Amy E and Chave, J{\'e}r{\^o}me and Wright, S Joseph and Sheremet'ev, Serge N and Jactel, Herv{\'e} and Baraloto, Christopher and Cerabolini, Bruno and Pierce, Simon and Shipley, Bill and Kirkup, Donald and Casanoves, Fernando and Joswig, Julia S and G{\"u}nther, Angela and Falczuk, Valeria and R{\"u}ger, Nadja and Mahecha, Miguel D and Gorn{\'e}, Lucas D},
@@ -265,6 +275,19 @@
   rating = {0},
   uri = {papers3://publication/doi/10.1038/nature16489},
   file = {/Users/dorme/Zotero/storage/RGG46LIG/Nature 2016 Díaz.pdf}
+}
+
+@book{duffie:2013a,
+  title = {Solar {{Engineering}} of {{Thermal Processes}}},
+  author = {Duffie, John A. and Beckman, William A.},
+  year = {2013},
+  month = apr,
+  publisher = {John Wiley \& Sons},
+  abstract = {The updated fourth edition of the "bible" of solar energy theory and applications Over several editions, Solar Engineering of Thermal Processes has become a classic solar engineering text and reference. This revised Fourth Edition offers current coverage of solar energy theory, systems design, and applications in different market sectors along with an emphasis on solar system design and analysis using simulations to help readers translate theory into practice. An important resource for students of solar engineering, solar energy, and alternative energy as well as professionals working in the power and energy industry or related fields, Solar Engineering of Thermal Processes, Fourth Edition features:  Increased coverage of leading-edge topics such as photovoltaics and the design of solar cells and heaters A brand-new chapter on applying CombiSys (a readymade TRNSYS simulation program available for free download) to simulate a solar heated house with solar- heated domestic hot water Additional simulation problems available through a companion website An extensive array of homework problems and exercises},
+  googlebooks = {5uDdUfMgXYQC},
+  isbn = {978-1-118-41541-2},
+  langid = {english},
+  keywords = {Technology & Engineering / Electronics / General,Technology & Engineering / Mechanical,Technology & Engineering / Power Resources / General}
 }
 
 @article{Farquhar:1980ft,
@@ -437,6 +460,26 @@
   file = {/Users/dorme/Zotero/storage/HREIVFC4/Journal of Physical and Chemical Reference Data 2009 Huber.pdf}
 }
 
+@book{iqbal:1983a,
+  title = {An Introduction to Solar Radiation},
+  author = {Iqbal, Mohammed},
+  year = {1983},
+  langid = {english}
+}
+
+@techreport{joshi:2022a,
+  title = {Plant-{{FATE}}: {{Predicting}} the Adaptive Responses of Biodiverse Plant Communities Using Functional-Trait Evolution},
+  author = {Joshi, Jaideep and Prentice, Iain Colin and Br{\"a}nnstr{\"o}m, {\AA}ke and Singh, Shipra and Hofhansl, Florian and Dieckmann, Ulf},
+  year = {2022},
+  month = mar,
+  number = {EGU22-9994},
+  institution = {Copernicus Meetings},
+  doi = {10.5194/egusphere-egu22-9994},
+  urldate = {2024-09-05},
+  langid = {english},
+  file = {/Users/dorme/Zotero/storage/47RVAZGK/EGU22-9994.html}
+}
+
 @article{Kattge:2007db,
   title = {Temperature Acclimation in a Biochemical Model of Photosynthesis: A Reanalysis of Data from 36 Species},
   author = {Kattge, Jens and Knorr, Wolfgang},
@@ -489,14 +532,6 @@
   file = {/Users/dorme/Zotero/storage/86NBGKCA/2020 Lancelot.pdf}
 }
 
-@article{lavergne:2022a,
-  title = {A Semi-Empirical Model for Primary Production, Isotopic Discrimination and Competition of {{C3}} and {{C4}} Plants},
-  author = {Lavergne, Ali{\'e}nor and Harrison, Sandy P. and Atsawawaranunt, Kamolphat and Dong, Ning and Prentice, Iain Colin},
-  year = {2022},
-  journal = {Global Ecology and Biogeography (submitted)},
-  file = {/Users/dorme/Zotero/storage/I797PRT2/Lavergneetal_GEB.docx}
-}
-
 @article{lavergne:2020a,
   title = {Impacts of Soil Water Stress on the Acclimated Stomatal Limitation of Photosynthesis: {{Insights}} from Stable Carbon Isotope Data},
   shorttitle = {Impacts of Soil Water Stress on the Acclimated Stomatal Limitation of Photosynthesis},
@@ -513,6 +548,14 @@
   abstract = {Atmospheric aridity and drought both influence physiological function in plant leaves, but their relative contributions to changes in the ratio of leaf internal to ambient partial pressure of CO2 ({$\chi$}) -- an index of adjustments in both stomatal conductance and photosynthetic rate to environmental conditions -- are difficult to disentangle. Many stomatal models predicting {$\chi$} include the influence of only one of these drivers. In particular, the least-cost optimality hypothesis considers the effect of atmospheric demand for water on {$\chi$} but does not predict how soils with reduced water further influence {$\chi$}, potentially leading to an overestimation of {$\chi$} under dry conditions. Here, we use a large network of stable carbon isotope measurements in C3 woody plants to examine the acclimated response of {$\chi$} to soil water stress. We estimate the ratio of cost factors for carboxylation and transpiration ({$\beta$}) expected from the theory to explain the variance in the data, and investigate the responses of {$\beta$} (and thus {$\chi$}) to soil water content and suction across seed plant groups, leaf phenological types and regions. Overall, {$\beta$} decreases linearly with soil drying, implying that the cost of water transport along the soil--plant--atmosphere continuum increases as water available in the soil decreases. However, despite contrasting hydraulic strategies, the stomatal responses of angiosperms and gymnosperms to soil water tend to converge, consistent with the optimality theory. The prediction of {$\beta$} as a simple, empirical function of soil water significantly improves {$\chi$} predictions by up to 6.3 {\textpm} 2.3\% (mean {\textpm} SD of adjusted-R2) over 1980--2018 and results in a reduction of around 2\% of mean {$\chi$} values across the globe. Our results highlight the importance of soil water status on stomatal functions and plant water-use efficiency, and suggest the implementation of trait-based hydraulic functions into the model to account for soil water stress.},
   langid = {english},
   file = {/Users/dorme/Zotero/storage/ECFRUWX5/Lavergne et al. - 2020 - Impacts of soil water stress on the acclimated sto.pdf}
+}
+
+@article{lavergne:2022a,
+  title = {A Semi-Empirical Model for Primary Production, Isotopic Discrimination and Competition of {{C3}} and {{C4}} Plants},
+  author = {Lavergne, Ali{\'e}nor and Harrison, Sandy P. and Atsawawaranunt, Kamolphat and Dong, Ning and Prentice, Iain Colin},
+  year = {2022},
+  journal = {Global Ecology and Biogeography (submitted)},
+  file = {/Users/dorme/Zotero/storage/I797PRT2/Lavergneetal_GEB.docx}
 }
 
 @article{Li:2014bc,
@@ -549,6 +592,22 @@
   rating = {0},
   uri = {papers3://publication/uuid/61D6E8CB-F257-4021-AC24-2DF4D72C298E},
   file = {/Users/dorme/Zotero/storage/J7WANJNI/2015 Lin-2.pdf}
+}
+
+@article{linacre:1968a,
+  title = {Estimating the Net-Radiation Flux},
+  author = {Linacre, E. T.},
+  year = {1968},
+  month = jan,
+  journal = {Agricultural Meteorology},
+  volume = {5},
+  number = {1},
+  pages = {49--63},
+  issn = {0002-1571},
+  doi = {10.1016/0002-1571(68)90022-8},
+  urldate = {2024-08-02},
+  abstract = {A major influence controlling the water loss from irrigated crops is the net-radiation intensity Qn, but measurements of this are not normally available, and so attempts are often made to deduce it from other climatic data, such as the solar-radiation. Here it is shown that the relationship between net and solar-radiation intensities depends on the degree of cloudiness and the ambient temperature. By making appropriate assumptions, a series of expressions for Qn is derived, with decreasing accuracy but increasing simplicity of estimation. It appears that clouds lower the net-radiation intensity when it exceeds a critical value in the region of 0.02 cal./cm2 min, but increase it when the intensity is lower.},
+  file = {/Users/dorme/Zotero/storage/UY4NRV4W/0002157168900228.html}
 }
 
 @article{long:1993a,
@@ -676,6 +735,32 @@
   file = {/Users/dorme/Zotero/storage/MDRBDVTF/Ecol Lett 2014 Prentice.pdf}
 }
 
+@article{purves:2008a,
+  title = {Predicting and Understanding Forest Dynamics Using a Simple Tractable Model},
+  author = {Purves, Drew W. and Lichstein, Jeremy W. and Strigul, Nikolay and Pacala, Stephen W.},
+  year = {2008},
+  month = nov,
+  journal = {Proceedings of the National Academy of Sciences},
+  volume = {105},
+  number = {44},
+  pages = {17018--17022},
+  issn = {0027-8424, 1091-6490},
+  doi = {10.1073/pnas.0807754105},
+  urldate = {2022-06-20},
+  abstract = {The perfect-plasticity approximation (PPA) is an analytically tractable model of forest dynamics, defined in terms of parameters for individual trees, including allometry, growth, and mortality. We estimated these parameters for the eight most common species on each of four soil types in the US Lake states (Michigan, Wisconsin, and Minnesota) by using short-term ({$\leq$}15-year) inventory data from individual trees. We implemented 100-year PPA simulations given these parameters and compared these predictions to chronosequences of stand development. Predictions for the timing and magnitude of basal area dynamics and ecological succession on each soil were accurate, and predictions for the diameter distribution of 100-year-old stands were correct in form and slope. For a given species, the PPA provides analytical metrics for early-successional performance (               H               20               , height of a 20-year-old open-grown tree) and late-successional performance (               {\^Z}               *, equilibrium canopy height in monoculture). These metrics predicted which species were early or late successional on each soil type. Decomposing               {\^Z}               * showed that (               i               ) succession is driven both by superior understory performance and superior canopy performance of late-successional species, and (               ii               ) performance differences primarily reflect differences in mortality rather than growth. The predicted late-successional dominants matched chronosequences on xeromesic (               Quercus rubra               ) and mesic (codominance by               Acer rubrum               and               Acer saccharum               ) soil. On hydromesic and hydric soils, the literature reports that the current dominant species in old stands (               Thuja occidentalis               ) is now failing to regenerate. Consistent with this, the PPA predicted that, on these soils, stands are now succeeding to dominance by other late-successional species (e.g.,               Fraxinus nigra               ,               A. rubrum               ).},
+  langid = {english},
+  file = {/Users/dorme/Zotero/storage/KI43FP4H/Purves et al. - 2008 - Predicting and understanding forest dynamics using.pdf}
+}
+
+@article{sandoval:in_prep,
+  title = {Aridity and Growth Temperature Effects on Phio Manuscript},
+  author = {Sandoval, David},
+  year = {in\_prep},
+  journal = {Placeholder},
+  volume = {?},
+  pages = {??-??}
+}
+
 @article{Smith:2019dv,
   title = {Global Photosynthetic Capacity Is Optimized to the Environment},
   author = {Smith, Nicholas G and Keenan, Trevor F and Colin Prentice, I and Wang, Han and Wright, Ian J. and Niinemets, {\"U}lo and Crous, Kristine Y and Domingues, Tomas F and Guerrieri, Rossella and Yoko Ishida, F and Kattge, Jens and Kruger, Eric L and Maire, Vincent and Rogers, Alistair and Serbin, Shawn P and Tarvainen, Lasse and Togashi, Henrique F and Townsend, Philip A and Wang, Meng and Weerasinghe, Lasantha K and Zhou, Shuang Xi},
@@ -696,25 +781,6 @@
   file = {/Users/dorme/Zotero/storage/EIWDBL6T/Ecol Lett 2019 Smith.pdf}
 }
 
-@article{Stocker:2020dh,
-  title = {P-Model v1.0: An Optimality-Based Light Use Efficiency Model for Simulating Ecosystem Gross Primary Production},
-  author = {Stocker, Benjamin D and Wang, Han and Smith, Nicholas G and Harrison, Sandy P and Keenan, Trevor F and Sandoval, David and Davis, Tyler and Prentice, I. Colin},
-  year = {2020},
-  journal = {Geoscientific Model Development},
-  volume = {13},
-  number = {3},
-  pages = {1545--1581},
-  doi = {10.5194/gmd-13-1545-2020},
-  date-added = {2020-11-30T12:24:06GMT},
-  date-modified = {2021-01-28T11:55:51GMT},
-  langid = {english},
-  local-url = {file://localhost/Users/dorme/References/Library.papers3/Articles/2020/Stocker/Geoscientific\%20Model\%20Development\%202020\%20Stocker.pdf},
-  rating = {0},
-  read = {Yes},
-  uri = {papers3://publication/doi/10.5194/gmd-13-1545-2020},
-  file = {/Users/dorme/Zotero/storage/J4YM5X2R/Geoscientific Model Development 2020 Stocker.pdf}
-}
-
 @article{Stocker:2018be,
   title = {Quantifying Soil Moisture Impacts on Light Use Efficiency across Biomes},
   author = {Stocker, Benjamin D and Zscheischler, Jakob and Keenan, Trevor F and Prentice, I. Colin and Penuelas, Josep and Seneviratne, Sonia I},
@@ -733,6 +799,25 @@
   rating = {0},
   uri = {papers3://publication/doi/10.1111/nph.15123},
   file = {/Users/dorme/Zotero/storage/E6PPD38Z/New Phytol. 2018 Stocker.pdf}
+}
+
+@article{Stocker:2020dh,
+  title = {P-Model v1.0: An Optimality-Based Light Use Efficiency Model for Simulating Ecosystem Gross Primary Production},
+  author = {Stocker, Benjamin D and Wang, Han and Smith, Nicholas G and Harrison, Sandy P and Keenan, Trevor F and Sandoval, David and Davis, Tyler and Prentice, I. Colin},
+  year = {2020},
+  journal = {Geoscientific Model Development},
+  volume = {13},
+  number = {3},
+  pages = {1545--1581},
+  doi = {10.5194/gmd-13-1545-2020},
+  date-added = {2020-11-30T12:24:06GMT},
+  date-modified = {2021-01-28T11:55:51GMT},
+  langid = {english},
+  local-url = {file://localhost/Users/dorme/References/Library.papers3/Articles/2020/Stocker/Geoscientific\%20Model\%20Development\%202020\%20Stocker.pdf},
+  rating = {0},
+  read = {Yes},
+  uri = {papers3://publication/doi/10.5194/gmd-13-1545-2020},
+  file = {/Users/dorme/Zotero/storage/J4YM5X2R/Geoscientific Model Development 2020 Stocker.pdf}
 }
 
 @article{Togashi:2018es,
@@ -809,6 +894,25 @@
   file = {/Users/dorme/Zotero/storage/N8LKZ4EP/Ecology and Evolution 2014 Walker.pdf}
 }
 
+@article{Wang:2017go,
+  title = {Towards a Universal Model for Carbon Dioxide Uptake by Plants},
+  author = {Wang, Han and Prentice, I. Colin and Keenan, Trevor F and Davis, Tyler W and Wright, Ian J. and Cornwell, William K and Evans, Bradley J and Peng, Changhui},
+  year = {2017},
+  month = sep,
+  journal = {Nature Plants},
+  pages = {1--8},
+  publisher = {Springer US},
+  doi = {10.1038/s41477-017-0006-8},
+  abstract = {Nature Plants, doi:10.1038/s41477-017-0006-8},
+  date-added = {2020-11-30T12:27:00GMT},
+  date-modified = {2021-01-28T09:14:19GMT},
+  local-url = {file://localhost/Users/dorme/References/Library.papers3/Articles/2017/Wang/Nature\%20Plants\%202017\%20Wang.pdf},
+  rating = {0},
+  read = {Yes},
+  uri = {papers3://publication/doi/10.1038/s41477-017-0006-8},
+  file = {/Users/dorme/Zotero/storage/D4RYI3NP/Nature Plants 2017 Wang.pdf}
+}
+
 @article{Wang:2020ik,
   title = {Acclimation of Leaf Respiration Consistent with Optimal Photosynthetic Capacity},
   author = {Wang, Han and Atkin, Owen K and Keenan, Trevor F and Smith, Nicholas G and Wright, Ian J. and Bloomfield, Keith J and Kattge, Jens and Reich, Peter B and Prentice, I. Colin},
@@ -829,25 +933,6 @@
   file = {/Users/dorme/Zotero/storage/2XYW4BF4/gcb15314-sup-0004-Supinfo.pdf;/Users/dorme/Zotero/storage/RAGU56IZ/Global Change Biol 2020 Wang.pdf}
 }
 
-@article{Wang:2017go,
-  title = {Towards a Universal Model for Carbon Dioxide Uptake by Plants},
-  author = {Wang, Han and Prentice, I. Colin and Keenan, Trevor F and Davis, Tyler W and Wright, Ian J. and Cornwell, William K and Evans, Bradley J and Peng, Changhui},
-  year = {2017},
-  month = sep,
-  journal = {Nature Plants},
-  pages = {1--8},
-  publisher = {Springer US},
-  doi = {10.1038/s41477-017-0006-8},
-  abstract = {Nature Plants, doi:10.1038/s41477-017-0006-8},
-  date-added = {2020-11-30T12:27:00GMT},
-  date-modified = {2021-01-28T09:14:19GMT},
-  local-url = {file://localhost/Users/dorme/References/Library.papers3/Articles/2017/Wang/Nature\%20Plants\%202017\%20Wang.pdf},
-  rating = {0},
-  read = {Yes},
-  uri = {papers3://publication/doi/10.1038/s41477-017-0006-8},
-  file = {/Users/dorme/Zotero/storage/D4RYI3NP/Nature Plants 2017 Wang.pdf}
-}
-
 @book{woolf:1968a,
   title = {On the {{Computation}} of {{Solar Elevation Angles}} and the {{Determination}} of {{Sunrise}} and {{Sunset Times}}},
   author = {Woolf, Harold M.},
@@ -856,53 +941,9 @@
   langid = {english}
 }
 
-@book{duffie:2013a,
-  title = {Solar {{Engineering}} of {{Thermal Processes}}},
-  author = {Duffie, John A. and Beckman, William A.},
-  year = {2013},
-  month = apr,
-  publisher = {John Wiley \& Sons},
-  abstract = {The updated fourth edition of the "bible" of solar energy theory and applications Over several editions, Solar Engineering of Thermal Processes has become a classic solar engineering text and reference. This revised Fourth Edition offers current coverage of solar energy theory, systems design, and applications in different market sectors along with an emphasis on solar system design and analysis using simulations to help readers translate theory into practice. An important resource for students of solar engineering, solar energy, and alternative energy as well as professionals working in the power and energy industry or related fields, Solar Engineering of Thermal Processes, Fourth Edition features:  Increased coverage of leading-edge topics such as photovoltaics and the design of solar cells and heaters A brand-new chapter on applying CombiSys (a readymade TRNSYS simulation program available for free download) to simulate a solar heated house with solar- heated domestic hot water Additional simulation problems available through a companion website An extensive array of homework problems and exercises},
-  googlebooks = {5uDdUfMgXYQC},
-  isbn = {978-1-118-41541-2},
-  langid = {english},
-  keywords = {Technology & Engineering / Electronics / General,Technology & Engineering / Mechanical,Technology & Engineering / Power Resources / General}
-}
-
-@article{linacre:1968a,
-  title = {Estimating the Net-Radiation Flux},
-  author = {Linacre, E. T.},
-  year = {1968},
-  month = jan,
-  journal = {Agricultural Meteorology},
-  volume = {5},
-  number = {1},
-  pages = {49--63},
-  issn = {0002-1571},
-  doi = {10.1016/0002-1571(68)90022-8},
-  urldate = {2024-08-02},
-  abstract = {A major influence controlling the water loss from irrigated crops is the net-radiation intensity Qn, but measurements of this are not normally available, and so attempts are often made to deduce it from other climatic data, such as the solar-radiation. Here it is shown that the relationship between net and solar-radiation intensities depends on the degree of cloudiness and the ambient temperature. By making appropriate assumptions, a series of expressions for Qn is derived, with decreasing accuracy but increasing simplicity of estimation. It appears that clouds lower the net-radiation intensity when it exceeds a critical value in the region of 0.02 cal./cm2 min, but increase it when the intensity is lower.},
-  file = {/Users/dorme/Zotero/storage/UY4NRV4W/0002157168900228.html}
-}
-
-@article{sandoval:in_prep,
-  title = {Aridity and Growth Temperature Effects on Phio Manuscript},
-  author = {Sandoval, David},
-  year = {in\_prep},
-  journal = {Placeholder},
-  volume = {?},
-  pages = {??-??}
-}
-
-@techreport{joshi:2022a,
-  title = {Plant-{{FATE}}: {{Predicting}} the Adaptive Responses of Biodiverse Plant Communities Using Functional-Trait Evolution},
-  author = {Joshi, Jaideep and Prentice, Iain Colin and Br{\"a}nnstr{\"o}m, {\AA}ke and Singh, Shipra and Hofhansl, Florian and Dieckmann, Ulf},
-  year = {2022},
-  month = mar,
-  number = {EGU22-9994},
-  institution = {Copernicus Meetings},
-  doi = {10.5194/egusphere-egu22-9994},
-  urldate = {2024-09-05},
-  langid = {english},
-  file = {/Users/dorme/Zotero/storage/47RVAZGK/EGU22-9994.html}
+@misc{zotero-2443a,
+  title = {Crown.Md\#cro{\dots} - {{JupyterLab}}},
+  urldate = {2024-09-30},
+  howpublished = {http://localhost:8888/lab/tree/source/users/demography/crown.md\#crown-radius-values},
+  file = {/Users/dorme/Zotero/storage/LHHVRPS9/crown.html}
 }

--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -6,12 +6,19 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: python3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
 
 # Canopy model
+
+:::{admonition} Warning
+
+This area of `pyrealm` is in active development and this notebook currently contains
+notes and initial demonstration code.
+
+:::
 
 This notebook walks through the steps in generating the canopy model as (hopefully) used
 in Plant-FATE.

--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -83,7 +83,7 @@ The {class}`~pyrealm.demography.canopy.Canopy` class automatically finds the can
 closure heights, given a {class}`~pyrealm.demography.community.Community` instance
 and the required canopy gap fraction.
 
-The code below creates a simple community and then fits the canopy model:
+The code below creates a simple community:
 
 ```{code-cell}
 # Two PFTs
@@ -245,11 +245,6 @@ ax.set_ylabel("Vertical height ($z$, m)")
 ax.set_xlabel("Community-wide projected area (m2)")
 ax.legend(frameon=False)
 ```
-
-The projected area from individual stems to each canopy layer can then be calculated at
-$z^*_l$ and hence the projected area of canopy **within each layer**.
-
-+++
 
 ### Light transmission through the canopy
 

--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -27,7 +27,7 @@ space $A$. When the area $A$ is filled, a new lower canopy layer is formed until
 of the individual crown area has been distributed across within the canopy.
 
 The key variables in calculating the canopy model are the crown projected area $A_p$
-and leaf projected projected area $\tilde{A}_{cp}(z)$, which are calculated for a stem
+and leaf projected area $\tilde{A}_{cp}(z)$, which are calculated for a stem
 of a given size using the  [crown model](./crown.md).
 
 ```{code-cell}

--- a/docs/source/users/demography/community.md
+++ b/docs/source/users/demography/community.md
@@ -1,0 +1,20 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: python3
+  language: python
+  name: python3
+---
+
+# Plant Communities
+
+:::{admonition} Warning
+
+This area of `pyrealm` is in active development.
+
+:::

--- a/docs/source/users/demography/community.md
+++ b/docs/source/users/demography/community.md
@@ -6,7 +6,7 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: python3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -18,3 +18,44 @@ kernelspec:
 This area of `pyrealm` is in active development.
 
 :::
+
+```{code-cell}
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+
+from pyrealm.demography.flora import PlantFunctionalType, Flora
+from pyrealm.demography.community import Community
+```
+
+```{code-cell}
+short_pft = PlantFunctionalType(
+    name="short", h_max=15, m=1.5, n=1.5, f_g=0, ca_ratio=380
+)
+tall_pft = PlantFunctionalType(name="tall", h_max=30, m=1.5, n=2, f_g=0.2, ca_ratio=500)
+
+# Create the flora
+flora = Flora([short_pft, tall_pft])
+
+# Create a simply community with three cohorts
+# - 15 saplings of the short PFT
+# - 5 larger stems of the short PFT
+# - 2 large stems of tall PFT
+
+community = Community(
+    flora=flora,
+    cell_area=32,
+    cell_id=1,
+    cohort_dbh_values=np.array([0.02, 0.20, 0.5]),
+    cohort_n_individuals=np.array([15, 5, 2]),
+    cohort_pft_names=np.array(["short", "short", "tall"]),
+)
+```
+
+```{code-cell}
+community
+```
+
+```{code-cell}
+
+```

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -43,31 +43,114 @@ from pyrealm.demography.crown import (
 ```
 
 The {mod}`pyrealm.demography` module uses three-dimensional model of crown shape to
-define the vertical distribution of leaf area. This is driven by four parameters within
-the {class}`~pyrealm.demography.flora.PlantFunctionalType`:
+define the vertical distribution of leaf area, following the implementation of crown
+shape in the Plant-FATE model {cite}`joshi:2022a`.
 
-* The `m` and `n` parameters that define the vertical shape of the crown profile.
-* The `ca_ratio` parameters that defines the size of the crown relative to the stem size.
-* The `f_g` parameter that define the crown gap fraction and sets the vertical
+## Crown traits
+
+The crown model for a plant functional type (PFT) is driven by four traits within
+the {class}`~pyrealm.demography.flora.PlantFunctionalType` class:
+
+* The `m` and `n` ($m, n$) traits set the vertical shape of the crown profile.
+* The `ca_ratio` trait sets the area of the crown ($A_c$) relative to the stem size.
+* The `f_g` ($f_g$) trait sets the crown gap fraction and sets the vertical
   distribution of leaves within the crown.
 
-The code below provides a demonstration of the impacts of each parameter and shows the
-use of `pyrealm` tools to visualise the crown model for individual stems.
+### Canopy shape
 
-## Crown shape parameters
+For a stem of height $H$, the $m$ and $n$ traits are used to calculate the *relative*
+crown radius $q(z)$ at a height $z$ of as:
 
-The `m` and `n` parameters define the vertical profile of the crown but are also define
-two  further parameters:
+$$
+q(z)= m n \left(\dfrac{z}{H}\right) ^ {n -1}
+    \left( 1 - \left(\dfrac{z}{H}\right) ^ n \right)^{m-1}
+$$
 
-* `q_m`, which is used to scale the size of the crown radius to match the expected crown
-  area, given the crown shape.
-* `z_max_prop`, which sets the height on the stem at which the maximum crown radius is found.
+In order to align the arbitrary relative radius values with the predictions of the
+T Model for the stem, we then need to find the height at which the relative radius
+is at its maximum and a scaling factor that will convert the relative area at this
+height to the expected crown area under the T Model. These can be calculated using
+the following two additional traits, which are invariant for a PFT.
 
-The code below calculates `q_m` and `z_max_prop` for combinations of `m` and `n` and
-then plots the resulting values.
+* `z_max_prop` ($p_{zm}$) sets the proportion of the height of the stem at which
+   the maximum relative crown radius is found.
+* `q_m` ($q_m$) is used to scale the size of the crown radius at $z_{max}$ to match
+   the expected crown area.
+
+$$
+\begin{align}
+p_{zm} &= \left(\dfrac{n-1}{m n -1}\right)^ {\tfrac{1}{n}}\\[8pt]
+q_m &= m n \left(\dfrac{n-1}{m n -1}\right)^ {1 - \tfrac{1}{n}}
+    \left(\dfrac{\left(m-1\right) n}{m n -1}\right)^ {m-1}
+\end{align}
+$$
+
+For individual stems, with expected height $H$ and crown area $A_c$, we can then
+calculate:
+
+* the height $z_m$ at which the maximum crown radius $r_m$ is found,
+* a height-specific scaling factor $r_0$ such that $\pi q(z_m)^2 = A_c$,
+* the actual crown radius $r(z)$ at a given height $z$.
+
+$$
+\begin{align}
+z_m &= H p_{zm}\\[8pt]
+r_0 &= \frac{1}{q_m}\sqrt{\frac{A_c}{\pi}}\\[8pt]
+r(z) &= r_0 \; q(z)
+\end{align}
+$$
+
+### Projected crown and leaf area
+
+From the crown radius profile, the model can then be used to calculate how crown area
+and leaf area accumulates from the top of the crown towards the ground, giving
+functions given height $z$ for:
+
+* the projected crown area $A_p(z)$, and
+* the projected leaf area $\tilde{A}_{cp}(z)$.
+
+The projected crown area is calculated for a stem of known height and crown area is:
+
+$$
+A_p(z)=
+\begin{cases}
+A_c, & z \le z_m \\
+A_c \left(\dfrac{q(z)}{q_m}\right)^2, & H > z > z_m \\
+0, & z > H
+\end{cases}
+$$
+
+That is, the projected crown area is zero above the top of the stem, increases to the
+expected crown area at $z_max$ and is then constant to ground level.
+
+The projected leaf area $\tilde{A}_{cp}(z)$ models how the vertical distribution of
+leaf area within the crown is modified by the crown gap fraction $f_g$. This trait
+models how leaf gaps higher in the crown are filled by leaf area at lower heights:
+it does not change the profile of the crown but allows leaf area in the crown to be
+displaced downwards. When $f_g = 0$, the projected crown and leaf areas are identical,
+but as $f_g \to 1$ the projected leaf area is pushed downwards.
+The calculation of $\tilde{A}_{cp}(z)$ is defined as:
+
+$$
+\tilde{A}_{cp}(z)=
+\begin{cases}
+0, & z \gt H \\
+A_c \left(\dfrac{q(z)}{q_m}\right)^2 \left(1 - f_g\right), & H \gt z \gt z_m \\
+Ac - A_c \left(\dfrac{q(z)}{q_m}\right)^2 f_g, & zm \gt z
+\end{cases}
+$$
+
+## Calculating crown model traits in `pyrealm`
+
+The {class}`~pyrealm.demography.flora.PlantFunctionalType` class is typically
+used to set specific PFTs, but the functions to calculate $q_m$ and $p_{zm}$
+are used directly below to provides a demonstration of the impacts of each trait.
 
 ```{code-cell}
+# Set a range of values for m and n traits
 m = n = np.arange(1.0, 5, 0.1)
+
+# Calculate the invariant q_m and z_max_prop traits
 q_m = calculate_crown_q_m(m=m, n=n[:, None])
 z_max_prop = calculate_crown_z_max_proportion(m=m, n=n[:, None])
 ```
@@ -90,36 +173,53 @@ ax2.set_ylabel("n")
 ax2.set_aspect("equal")
 ```
 
-## Plotting crown profiles
+## Crown calculations in `pyrealm`
 
-The examples below show the calculation of crown profiles for a set of plant functional
-types (PFTs) with differing crown trait values. We first need to create a
-{class}`~pyrealm.demography.flora.Flora` object that defines those PFTs.
+The examples below show the calculation of crown variables in `pyrealm`.
+
+### Calculting crown profiles
+
+The  {class}`~pyrealm.demography.crown.CrownProfile` class is used to calculate crown
+profiles for PFTs. It requires:
+
+* a {class}`~pyrealm.demography.flora.Flora` instance providing a set of PFTs to be
+  compared,
+* a {class}`~pyrealm.demography.t_model_functions.StemAllometry` instance setting the
+  specific stem sizes for the profile, and
+* a set of heights at which to estimate the profile variables
+
+The code below creates a set of PFTS with differing crown trait values and then creates
+a `Flora` object using the PFTs.
 
 ```{code-cell}
-flora = Flora(
-    [
-        PlantFunctionalType(name="short", h_max=20, m=1.5, n=1.5, f_g=0, ca_ratio=20),
-        PlantFunctionalType(
-            name="medium", h_max=20, m=1.5, n=4, f_g=0.05, ca_ratio=500
-        ),
-        PlantFunctionalType(name="tall", h_max=20, m=4, n=1.5, f_g=0.2, ca_ratio=2000),
-    ]
-)
+# A PFT with a small crown area and equal m and n values
+narrow_pft = PlantFunctionalType(name="narrow", h_max=20, m=1.5, n=1.5, ca_ratio=20)
+# A PFT with an intermediate crown area  and m < n
+medium_pft = PlantFunctionalType(name="medium", h_max=20, m=1.5, n=4, ca_ratio=500)
+# A PFT with a wide crown area and m > n
+wide_pft = PlantFunctionalType(name="wide", h_max=20, m=4, n=1.5, ca_ratio=2000)
 
+# Generate a Flora instance using those PFTs
+flora = Flora([narrow_pft, medium_pft, wide_pft])
 flora
 ```
 
+The Flora object can also be used to show a table of canopy variables:
+
 ```{code-cell}
-pd.DataFrame({k: getattr(flora, k) for k in flora.trait_attrs})
+# TODO - add a Flora.to_pandas() method
+flora_data = pd.DataFrame({k: getattr(flora, k) for k in flora.trait_attrs})
+flora_data[["name", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]]
 ```
 
-We then also need to specify the size of a stem of each PFT, along with the resulting
-allometric predictions from the T Model.
+The next section of code generates the `StemAllometry` to use for the profiles.
+The T Model uses DBH to define stem size - here the the code is being used to
+back-calculate the required DBH values to give three stems with similar heights
+near the maximum height for each PFT.
 
 ```{code-cell}
-# Generate the expected stem allometries at a single height for each PFT
-stem_height = np.array([18, 18, 18])
+# Generate the expected stem allometries at similar heights for each PFT
+stem_height = np.array([19, 17, 15])
 stem_dbh = calculate_dbh_from_height(
     a_hd=flora.a_hd, h_max=flora.h_max, stem_height=stem_height
 )
@@ -127,78 +227,63 @@ stem_dbh
 ```
 
 ```{code-cell}
+# Calculate the stem allometries
 allometry = StemAllometry(stem_traits=flora, at_dbh=stem_dbh)
 ```
 
-We can use {mod}`pandas` to visualise those allometric predictions.
+We can again use {mod}`pandas` to get a table of those allometric predictions:
 
 ```{code-cell}
 pd.DataFrame({k: getattr(allometry, k) for k in allometry.allometry_attrs})
 ```
 
-We can now use the {class}`~pyrealm.demography.crown.CrownProfile` class to
-calculate the crown profile for each stem for a set of vertical heights. The heights
-need to be defined as a column array, that is with a shape `(N, 1)`, in order to show
-that we want the crown variables to be calculated at each height for each PFT.
+Finally, we can define a set of vertical heights. In order to calculate the
+variables for each PFT at each height, this needs to be provided as a column array,
+that is with a shape `(N, 1)`.
+
+We can then calculate the crown profiles.
 
 ```{code-cell}
 # Create a set of vertical heights as a column array.
-z = np.linspace(0, 18.0, num=181)[:, None]
+z = np.linspace(-1, 20.0, num=211)[:, None]
 
 # Calculate the crown profile across those heights for each PFT
 crown_profiles = CrownProfile(stem_traits=flora, stem_allometry=allometry, z=z)
 ```
 
-The `crown_profiles` object is a dictionary containing values for four crown profile
-variables.
+The `crown_profiles` object then provides the four crown profile attributes describe
+above calculated at each height $z$:
 
-* The relative crown radius: this value is driven purely by `m`, `n` and the stem height
-  and defines the vertical profile of the crown.
-* The crown radius: this is simply a rescaling of the relative radius so that the
-  maximum crown radius matches the expected crown area predicted by the allometry of the
-  T Model.
-* The projected crown area: this value shows how crown area accumulates from the top of
-  the crown to the ground.
-* The projected leaf area: this value shows how _leaf_ area accumulates from the top of
-  the crown to the ground. The difference from the crown area is driven by the crown gap
-  fraction for a given PFT.
+* The relative crown radius $q(z)$
+* The crown radius $r(z)$
+* The projected crown area
+* The projected leaf area
 
 ```{code-cell}
 crown_profiles
 ```
 
-### Crown radius values
-
-The relative crown radius values are arbitrary - they simply define the shape of the
-vertical profile. For the example PFTs in the `Flora` object, the maximum relative
-radius values on each stem are:
-
-```{code-cell}
-max_relative_crown_radius = crown_profiles.relative_crown_radius.max(axis=0)
-print(max_relative_crown_radius)
-```
-
-However the scaled maximum radius values match the expected crown area in the allometry
-table above
-
-```{code-cell}
-max_crown_radius = crown_profiles.crown_radius.max(axis=0)
-print(max_crown_radius)
-print(max_crown_radius**2 * np.pi)
-```
+### Visualising crown profiles
 
 The code below generates a plot of the vertical shape profiles of the crowns for each
 stem. For each stem:
 
-* the dashed line shows how the relative crown radius varies with height,
-* the solid line shows the actual crown radius profile with height, and
-* the dotted line shows the height at which the maximum crown radius is found.
+* the dashed line shows how the relative crown radius $q(z)$ varies with height $z$,
+* the solid line shows the actual crown radius $r)z)$ varies with height, and
+* the dotted horizontal line shows the height at which the maximum crown radius is
+  found ($z_max$).
+
+Note that the equation for the relative radius $q(z)$ does define values where
+$z <0$ or $z > H$.
 
 ```{code-cell}
 fig, ax = plt.subplots(ncols=1)
 
 # Find the maximum of the actual and relative maximum crown widths
+max_relative_crown_radius = np.nanmax(crown_profiles.relative_crown_radius, axis=0)
+max_crown_radius = np.nanmax(crown_profiles.crown_radius, axis=0)
 stem_max_width = np.maximum(max_crown_radius, max_relative_crown_radius)
+
 
 for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 12), ("r", "g", "b")):
 
@@ -229,32 +314,51 @@ for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 12), ("r", "g", "b")):
 ax.set_aspect(aspect=1)
 ```
 
-### Projected crown and leaf areas
-
-We can use the crown profile to generate projected area plots, but it is much easier to
-compare the effects when comparing stems with similar crown areas. The code below
-generates these new predictions for a new set of PFTs.
+We can also use the `CanopyProfile` class with a single row of heights to calculate
+the crown profile at the expected $z_max$ and show that this matches the expected
+crown area from the T Model allometry.
 
 ```{code-cell}
-flora2 = Flora(
-    [
-        PlantFunctionalType(name="short", h_max=20, m=1.5, n=1.5, f_g=0, ca_ratio=380),
-        PlantFunctionalType(
-            name="medium", h_max=20, m=1.5, n=4, f_g=0.05, ca_ratio=400
-        ),
-        PlantFunctionalType(name="tall", h_max=20, m=4, n=1.5, f_g=0.2, ca_ratio=420),
-    ]
-)
-
-allometry2 = StemAllometry(stem_traits=flora2, at_dbh=stem_dbh)
-
-
 # Calculate the crown profile across those heights for each PFT
-crown_profiles2 = CrownProfile(stem_traits=flora2, stem_allometry=allometry2, z=z)
+z_max = flora.z_max_prop * stem_height
+profile_at_zmax = CrownProfile(stem_traits=flora, stem_allometry=allometry, z=z_max)
+
+print(profile_at_zmax.crown_radius**2 * np.pi)
+print(allometry.crown_area)
 ```
 
-The plot below shows how projected crown area (solid lines) and leaf area (dashed lines)
-change with height along the stem.
+### Visualising crown and leaf projected areas
+
+We can also use the crown profile to generate projected area plots. This is hard to see
+using the PFTs defined above because they have very different crown areas, so the code
+below generates new profiles for a new set of PFTs that have similar crown area ratios
+but different shapes and gap fractions.
+
+```{code-cell}
+no_gaps_pft = PlantFunctionalType(
+    name="no_gaps", h_max=20, m=1.5, n=1.5, f_g=0, ca_ratio=380
+)
+few_gaps_pft = PlantFunctionalType(
+    name="few_gaps", h_max=20, m=1.5, n=4, f_g=0.05, ca_ratio=400
+)
+many_gaps_pft = PlantFunctionalType(
+    name="many_gaps", h_max=20, m=4, n=1.5, f_g=0.2, ca_ratio=420
+)
+
+# Calculate allometries for each PFT at the same stem DBH
+area_stem_dbh = np.array([0.4, 0.4, 0.4])
+area_flora = Flora([no_gaps_pft, few_gaps_pft, many_gaps_pft])
+area_allometry = StemAllometry(stem_traits=area_flora, at_dbh=area_stem_dbh)
+
+# Calculate the crown profiles across those heights for each PFT
+area_z = np.linspace(0, area_allometry.stem_height.max(), 201)[:, None]
+area_crown_profiles = CrownProfile(
+    stem_traits=area_flora, stem_allometry=area_allometry, z=area_z
+)
+```
+
+The plot below then shows how projected crown area (solid lines) and leaf area (dashed
+lines) change with height along the stem.
 
 * The projected crown area increases from zero at the top of the crown until it reaches
   the maximum crown radius, at which point it remains constant down to ground level. The
@@ -271,13 +375,17 @@ fig, ax = plt.subplots(ncols=1)
 
 for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 10), ("r", "g", "b")):
 
-    ax.plot(crown_profiles2.projected_crown_area[:, pft_idx], z, color=colour)
+    ax.plot(area_crown_profiles.projected_crown_area[:, pft_idx], area_z, color=colour)
     ax.plot(
-        crown_profiles2.projected_leaf_area[:, pft_idx],
-        z,
+        area_crown_profiles.projected_leaf_area[:, pft_idx],
+        area_z,
         color=colour,
         linestyle="--",
     )
     ax.set_xlabel("Projected area (m2)")
     ax.set_ylabel("Height above ground (m)")
+```
+
+```{code-cell}
+
 ```

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -136,10 +136,10 @@ We can use {mod}`pandas` to visualise those allometric predictions.
 pd.DataFrame({k: getattr(allometry, k) for k in allometry.allometry_attrs})
 ```
 
-We can now use the {meth}`~pyrealm.demography.flora.Flora.get_canopy_profile` method to
-calculate the canopy profile for each stem for a set of vertical heights. The heights
+We can now use the {class}`~pyrealm.demography.crown.CrownProfile` class to
+calculate the crown profile for each stem for a set of vertical heights. The heights
 need to be defined as a column array, that is with a shape `(N, 1)`, in order to show
-that we want the canopy variables to be calculated at each height for each PFT.
+that we want the crown variables to be calculated at each height for each PFT.
 
 ```{code-cell}
 # Create a set of vertical heights as a column array.
@@ -253,15 +253,15 @@ crown_profiles2 = CrownProfile(stem_traits=flora2, stem_allometry=allometry2, z=
 The plot below shows how projected crown area (solid lines) and leaf area (dashed lines)
 change with height along the stem.
 
-* The projected crown area increases from zero at the top of the canopy, according to
-  the canopy profile, until it reaches the maximum crown radius, at which point it
-  remains constant down to ground level. The total crown areas differs for each stem
-  because of the slightly different values used for the crown area ratio.
+* The projected crown area increases from zero at the top of the crown until it reaches
+  the maximum crown radius, at which point it remains constant down to ground level. The
+  total crown areas differs for each stem because of the slightly different values used
+  for the crown area ratio.
 
 * The projected leaf area is very similar but leaf area is displaced towards the ground
   because of the crown gap fraction (`f_g`). Where `f_g = 0` (the red line), the two
   lines are identical, but as `f_g` increases, more of the leaf area is displaced down
-  within the canopy.
+  within the crown.
 
 ```{code-cell}
 fig, ax = plt.subplots(ncols=1)

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -1,0 +1,282 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# The tree crown model
+
+:::{admonition} Warning
+
+This area of `pyrealm` is in active development and this notebook currently contains
+notes and initial demonstration code.
+
+:::
+
+```{code-cell}
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+
+from pyrealm.demography.flora import (
+    calculate_crown_q_m,
+    calculate_crown_z_max_proportion,
+    PlantFunctionalType,
+    Flora,
+)
+
+from pyrealm.demography.t_model_functions import (
+    calculate_dbh_from_height,
+    StemAllometry,
+)
+
+from pyrealm.demography.crown import (
+    CrownProfile,
+)
+```
+
+The {mod}`pyrealm.demography` module uses three-dimensional model of crown shape to
+define the vertical distribution of leaf area. This is driven by four parameters within
+the {class}`~pyrealm.demography.flora.PlantFunctionalType`:
+
+* The `m` and `n` parameters that define the vertical shape of the crown profile.
+* The `ca_ratio` parameters that defines the size of the crown relative to the stem size.
+* The `f_g` parameter that define the crown gap fraction and sets the vertical
+  distribution of leaves within the crown.
+
+The code below provides a demonstration of the impacts of each parameter and shows the
+use of `pyrealm` tools to visualise the crown model for individual stems.
+
+## Crown shape parameters
+
+The `m` and `n` parameters define the vertical profile of the crown but are also define
+two  further parameters:
+
+* `q_m`, which is used to scale the size of the crown radius to match the expected crown
+  area, given the crown shape.
+* `z_max_prop`, which sets the height on the stem at which the maximum crown radius is found.
+
+The code below calculates `q_m` and `z_max_prop` for combinations of `m` and `n` and
+then plots the resulting values.
+
+```{code-cell}
+m = n = np.arange(1.0, 5, 0.1)
+q_m = calculate_crown_q_m(m=m, n=n[:, None])
+z_max_prop = calculate_crown_z_max_proportion(m=m, n=n[:, None])
+```
+
+```{code-cell}
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(10.9, 4))
+
+# Plot q_m as a function of m and n
+cntr_set1 = ax1.contourf(m, n, q_m, levels=10)
+fig.colorbar(cntr_set1, ax=ax1, label="q_m")
+ax1.set_xlabel("m")
+ax1.set_ylabel("n")
+ax1.set_aspect("equal")
+
+# Plot z_max_prop as a function of m and n
+cntr_set2 = ax2.contourf(m, n, z_max_prop, levels=10)
+fig.colorbar(cntr_set2, ax=ax2, label="z_max_prop")
+ax2.set_xlabel("m")
+ax2.set_ylabel("n")
+ax2.set_aspect("equal")
+```
+
+## Plotting crown profiles
+
+The examples below show the calculation of crown profiles for a set of plant functional
+types (PFTs) with differing crown trait values. We first need to create a
+:class:`~pyrealm.demography.flora.Flora` object that defines those PFTs.
+
+```{code-cell}
+flora = Flora(
+    [
+        PlantFunctionalType(name="short", h_max=20, m=1.5, n=1.5, f_g=0, ca_ratio=20),
+        PlantFunctionalType(
+            name="medium", h_max=20, m=1.5, n=4, f_g=0.05, ca_ratio=500
+        ),
+        PlantFunctionalType(name="tall", h_max=20, m=4, n=1.5, f_g=0.2, ca_ratio=2000),
+    ]
+)
+
+flora
+```
+
+```{code-cell}
+pd.DataFrame({k: getattr(flora, k) for k in flora.trait_attrs})
+```
+
+We then also need to specify the size of a stem of each PFT, along with the resulting
+allometric predictions from the T Model.
+
+```{code-cell}
+# Generate the expected stem allometries at a single height for each PFT
+stem_height = np.array([18, 18, 18])
+stem_dbh = calculate_dbh_from_height(
+    a_hd=flora.a_hd, h_max=flora.h_max, stem_height=stem_height
+)
+stem_dbh
+```
+
+```{code-cell}
+allometry = StemAllometry(stem_traits=flora, at_dbh=stem_dbh)
+```
+
+We can use {mod}`pandas` to visualise those allometric predictions.
+
+```{code-cell}
+pd.DataFrame({k: getattr(allometry, k) for k in allometry.allometry_attrs})
+```
+
+We can now use the {meth}`~pyrealm.demography.flora.Flora.get_canopy_profile` method to
+calculate the canopy profile for each stem for a set of vertical heights. The heights
+need to be defined as a column array, that is with a shape `(N, 1)`, in order to show
+that we want the canopy variables to be calculated at each height for each PFT.
+
+```{code-cell}
+# Create a set of vertical heights as a column array.
+z = np.linspace(0, 18.0, num=181)[:, None]
+
+# Calculate the crown profile across those heights for each PFT
+crown_profiles = CrownProfile(stem_traits=flora, stem_allometry=allometry, z=z)
+```
+
+The `crown_profiles` object is a dictionary containing values for four crown profile
+variables.
+
+* The relative crown radius: this value is driven purely by `m`, `n` and the stem height
+  and defines the vertical profile of the crown.
+* The crown radius: this is simply a rescaling of the relative radius so that the
+  maximum crown radius matches the expected crown area predicted by the allometry of the
+  T Model.
+* The projected crown area: this value shows how crown area accumulates from the top of
+  the crown to the ground.
+* The projected leaf area: this value shows how _leaf_ area accumulates from the top of
+  the crown to the ground. The difference from the crown area is driven by the crown gap
+  fraction for a given PFT.
+
+```{code-cell}
+crown_profiles
+```
+
+### Crown radius values
+
+The relative crown radius values are arbitrary - they simply define the shape of the
+vertical profile. For the example PFTs in the `Flora` object, the maximum relative
+radius values on each stem are:
+
+```{code-cell}
+max_relative_crown_radius = crown_profiles.relative_crown_radius.max(axis=0)
+print(max_relative_crown_radius)
+```
+
+However the scaled maximum radius values match the expected crown area in the allometry
+table above
+
+```{code-cell}
+max_crown_radius = crown_profiles.crown_radius.max(axis=0)
+print(max_crown_radius)
+print(max_crown_radius**2 * np.pi)
+```
+
+The code below generates a plot of the vertical shape profiles of the crowns for each
+stem. For each stem:
+
+* the dashed line shows how the relative crown radius varies with height,
+* the solid line shows the actual crown radius profile with height, and
+* the dotted line shows the height at which the maximum crown radius is found.
+
+```{code-cell}
+fig, ax = plt.subplots(ncols=1)
+
+# Find the maximum of the actual and relative maximum crown widths
+stem_max_width = np.maximum(max_crown_radius, max_relative_crown_radius)
+
+for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 12), ("r", "g", "b")):
+
+    # Plot relative radius either side of offset
+    stem_qz = crown_profiles.relative_crown_radius[:, pft_idx]
+    ax.plot(stem_qz + offset, z, color=colour, linestyle="--", linewidth=1)
+    ax.plot(-stem_qz + offset, z, color=colour, linestyle="--", linewidth=1)
+
+    # Plot actual crown radius either side of offset
+    stem_rz = crown_profiles.crown_radius[:, pft_idx]
+    ax.plot(stem_rz + offset, z, color=colour)
+    ax.plot(-stem_rz + offset, z, color=colour)
+
+    # Add the height of maximum crown radius
+    stem_rz_max = stem_max_width[pft_idx]
+
+    ax.plot(
+        [offset - stem_rz_max, offset + stem_rz_max],
+        [allometry.crown_z_max[pft_idx]] * 2,
+        color=colour,
+        linewidth=1,
+        linestyle=":",
+    )
+
+ax.set_aspect(aspect=1)
+```
+
+### Projected crown and leaf areas
+
+We can use the crown profile to generate projected area plots, but it is much easier to
+compare the effects when comparing stems with similar crown areas. The code below
+generates these new predictions for a new set of PFTs.
+
+```{code-cell}
+flora2 = Flora(
+    [
+        PlantFunctionalType(name="short", h_max=20, m=1.5, n=1.5, f_g=0, ca_ratio=380),
+        PlantFunctionalType(
+            name="medium", h_max=20, m=1.5, n=4, f_g=0.05, ca_ratio=400
+        ),
+        PlantFunctionalType(name="tall", h_max=20, m=4, n=1.5, f_g=0.2, ca_ratio=420),
+    ]
+)
+
+allometry2 = StemAllometry(stem_traits=flora2, at_dbh=stem_dbh)
+
+
+# Calculate the crown profile across those heights for each PFT
+crown_profiles2 = CrownProfile(stem_traits=flora2, stem_allometry=allometry2, z=z)
+```
+
+The plot below shows how projected crown area (solid lines) and leaf area (dashed lines)
+change with height along the stem.
+
+* The projected crown area increases from zero at the top of the canopy, according to
+  the canopy profile, until it reaches the maximum crown radius, at which point it
+  remains constant down to ground level. The total crown areas differs for each stem
+  because of the slightly different values used for the crown area ratio.
+
+* The projected leaf area is very similar but leaf area is displaced towards the ground
+  because of the crown gap fraction (`f_g`). Where `f_g = 0` (the red line), the two
+  lines are identical, but as `f_g` increases, more of the leaf area is displaced down
+  within the canopy.
+
+```{code-cell}
+fig, ax = plt.subplots(ncols=1)
+
+for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 10), ("r", "g", "b")):
+
+    ax.plot(crown_profiles2.projected_crown_area[:, pft_idx], z, color=colour)
+    ax.plot(
+        crown_profiles2.projected_leaf_area[:, pft_idx],
+        z,
+        color=colour,
+        linestyle="--",
+    )
+```
+
+```{code-cell}
+
+```

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -386,6 +386,54 @@ for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 10), ("r", "g", "b")):
     ax.set_ylabel("Height above ground (m)")
 ```
 
+We can also generate predictions for a single PFT with varying crown gap fraction. In
+the plot below, note that all leaf area is above $z_{max}$ when $f_g=1$ and all leaf
+area is *below*
+
+```{code-cell}
+fig, ax = plt.subplots(ncols=1)
+
+# Loop over f_g values
+for f_g in np.linspace(0, 1, num=11):
+
+    label = None
+    colour = "gray"
+
+    if f_g == 0:
+        label = "$f_g=0$"
+        colour = "red"
+    elif f_g == 1:
+        label = "$f_g=1$"
+        colour = "blue"
+
+    # Create a flora with a single PFT with current f_g and then generate a
+    # stem allometry and crown profile
+    flora_f_g = Flora(
+        [PlantFunctionalType(name="example", h_max=20, m=2, n=2, f_g=f_g)]
+    )
+    allometry_f_g = StemAllometry(stem_traits=flora_f_g, at_dbh=np.array([0.4]))
+    profile = CrownProfile(
+        stem_traits=flora_f_g, stem_allometry=allometry_f_g, z=area_z
+    )
+
+    # Plot the projected leaf area with height
+    ax.plot(profile.projected_leaf_area, area_z, color=colour, label=label, linewidth=1)
+
+# Add a horizontal line for z_max
+ax.plot(
+    [-1, allometry_f_g.crown_area[0] + 1],
+    [allometry_f_g.crown_z_max, allometry_f_g.crown_z_max],
+    linestyle="--",
+    color="black",
+    label="$z_{max}$",
+    linewidth=1,
+)
+
+ax.set_ylabel(r"Vertical height ($z$, m)")
+ax.set_xlabel(r"Projected leaf area ($\tilde{A}_{cp}(z)$, m2)")
+ax.legend(frameon=False)
+```
+
 ```{code-cell}
 
 ```

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -94,7 +94,7 @@ ax2.set_aspect("equal")
 
 The examples below show the calculation of crown profiles for a set of plant functional
 types (PFTs) with differing crown trait values. We first need to create a
-:class:`~pyrealm.demography.flora.Flora` object that defines those PFTs.
+{class}`~pyrealm.demography.flora.Flora` object that defines those PFTs.
 
 ```{code-cell}
 flora = Flora(
@@ -223,6 +223,9 @@ for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 12), ("r", "g", "b")):
         linestyle=":",
     )
 
+    ax.set_xlabel("Crown profile")
+    ax.set_ylabel("Height above ground (m)")
+
 ax.set_aspect(aspect=1)
 ```
 
@@ -275,8 +278,6 @@ for pft_idx, offset, colour in zip((0, 1, 2), (0, 5, 10), ("r", "g", "b")):
         color=colour,
         linestyle="--",
     )
-```
-
-```{code-cell}
-
+    ax.set_xlabel("Projected area (m2)")
+    ax.set_ylabel("Height above ground (m)")
 ```

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -1,0 +1,121 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Plant Functional Types and the Flora object
+
+:::{admonition} Warning
+
+This area of `pyrealm` is in active development and this notebook currently contains
+notes and initial demonstration code.
+
+:::
+
+```{code-cell}
+from matplotlib import pyplot as plt
+import numpy as np
+
+from pyrealm.demography.flora import PlantFunctionalType, Flora
+```
+
+The code below creates a simple `Flora` object containing 3 plant functional types with
+different maximum stem heights.
+
+```{code-cell}
+flora = Flora(
+    [
+        PlantFunctionalType(name="short", h_max=10),
+        PlantFunctionalType(name="medium", h_max=20),
+        PlantFunctionalType(name="tall", h_max=30),
+    ]
+)
+
+flora
+```
+
+We can visualise how the stem size, canopy size and various masses of a plant functional
+type change with stem diameter by using the `Flora.get_allometries` method. This takes
+an array of values for diameter at breast height (metres) and returns a dictionary
+containing the predictions of the T Model for:
+
+* Stem height ('stem_height', m)
+* Crown area ('crown_area', m2)
+* Crown fraction ('crown_fraction', -)
+* Stem mass ('stem_mass', kg)
+* Foliage mass ('foliage_mass', kg)
+* Sapwood mass ('sapwood_mass', kg)
+
+The returned values in the dictionary are 2 dimensional arrays with each DBH value as a
+row and each PFT as a column. This makes them convenient to plot using `matplotlib`.
+
+```{code-cell}
+dbh = np.arange(0, 1.6, 0.01)[:, None]
+allometries = flora.get_allometries(dbh=dbh)
+```
+
+The code below shows how to use the returned allometries to generate a plot of the
+scaling relationships across all of the PFTs in a `Flora` instance.
+
+```{code-cell}
+fig, axes = plt.subplots(ncols=2, nrows=3, sharex=True, figsize=(10, 8))
+
+plot_details = [
+    ("stem_height", "Stem height (m)"),
+    ("crown_area", "Crown area (m2)"),
+    ("crown_fraction", "Crown fraction (-)"),
+    ("stem_mass", "Stem mass (kg)"),
+    ("foliage_mass", "Foliage mass (kg)"),
+    ("sapwood_mass", "Sapwood mass (kg)"),
+]
+
+for ax, (var, ylab) in zip(axes.flatten(), plot_details):
+    ax.plot(dbh, allometries[var], label=flora.keys())
+    ax.set_xlabel("Diameter at breast height (m)")
+    ax.set_ylabel(ylab)
+
+    if var == "sapwood_mass":
+        ax.legend(frameon=False)
+```
+
+```{code-cell}
+potential_gpp = np.repeat(55, dbh.size)[:, None]
+allocation = flora.get_allocation(dbh=dbh, potential_gpp=potential_gpp)
+```
+
+```{code-cell}
+fig, axes = plt.subplots(ncols=2, nrows=5, sharex=True, figsize=(10, 12))
+
+plot_details = [
+    ("whole_crown_gpp", "whole_crown_gpp"),
+    ("sapwood_respiration", "sapwood_respiration"),
+    ("foliar_respiration", "foliar_respiration"),
+    ("fine_root_respiration", "fine_root_respiration"),
+    ("npp", "npp"),
+    ("turnover", "turnover"),
+    ("delta_dbh", "delta_dbh"),
+    ("delta_stem_mass", "delta_stem_mass"),
+    ("delta_foliage_mass", "delta_foliage_mass"),
+]
+
+axes = axes.flatten()
+
+for ax, (var, ylab) in zip(axes, plot_details):
+    ax.plot(dbh, allocation[var], label=flora.keys())
+    ax.set_xlabel("Diameter at breast height (m)")
+    ax.set_ylabel(ylab)
+
+    if var == "whole_crown_gpp":
+        ax.legend(frameon=False)
+
+# Delete unused panel in 5 x 2 grid
+fig.delaxes(axes[-1])
+```

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -95,7 +95,7 @@ the PlantFATE model {cite}`joshi:2022a`.
 
 The {class}`~pyrealm.demography.flora.PlantFunctionalType` class is used define a PFT
 with a given name, along with the trait values associated with the PFT. By default,
-values for each trait are taken from Table 1 of {cite}`Li:2014bc`, but these can be
+values for each trait are taken from Table 1 of {cite:t}`Li:2014bc`, but these can be
 adjusted for different PFTs. The code below contains three examples that just differ in
 their maximum height.
 

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -28,9 +28,7 @@ from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 
-from pyrealm.demography.flora import PlantFunctionalType, Flora
-
-from pyrealm.demography.t_model_functions import StemAllocation, StemAllometry
+from pyrealm.demography.flora import PlantFunctionalType, Flora, StemTraits
 ```
 
 ## Plant traits
@@ -114,6 +112,16 @@ The traits values set for a PFT instance can then be shown:
 short_pft
 ```
 
+:::{admonition} Info
+
+In addition, `pyrealm` also defines the
+{class}`~pyrealm.demography.flora.PlantFunctionalTypeStrict` class. This version of the
+class requires that all trait values be provided when creating an instance, rather than
+falling back to the default values as above. This is mostly used within the `pyrealm`
+code for loading PFT data from files.
+
+:::
+
 ## The Flora class
 
 The {class}`~pyrealm.demography.flora.Flora` class is used to collect a list of PFTs
@@ -131,173 +139,25 @@ flora
 pd.DataFrame({k: getattr(flora, k) for k in flora.trait_attrs})
 ```
 
-You can also create `Flora` instances using PFT data stored TOML, JSON and CSV file formats.
+You can also create `Flora` instances using PFT data stored TOML, JSON and CSV file
+formats.
 
-## Stem allometry
+## The StemTraits class
 
-We can visualise how the stem size, canopy size and various masses of PFTs change with
-stem diameter by using the {class}`~pyrealm.demography.t_model_functions.StemAllometry`
-class. Creating a `StemAllometry` instance needs an existing `Flora` instance and an
-array of values for diameter at breast height (DBH, metres). The returned class contains
-the predictions of the T Model for:
+The {class}`~pyrealm.demography.flora.StemTraits` class is used to hold arrays of the
+same PFT traits across any number of stems. Unlike the
+{class}`~pyrealm.demography.flora.Flora` class, the `name` attribute does not need to be
+unique. It is mostly used within `pyrealm` to represent the stem traits of plant cohorts
+within {class}`~pyrealm.demography.community.Community` objects.
 
-* Stem height (`stem_height`, m),
-* Crown area (`crown_area`, m2),
-* Crown fraction (`crown_fraction`, -),
-* Stem mass (`stem_mass`, kg),
-* Foliage mass (`foliage_mass`, kg),
-* Sapwood mass (`sapwood_mass`, kg),
-* Crown radius scaling factor (`crown_r0`, -), and
-* Height of maximum crown radius (`crown_z_max`, m).
-
-The DBH input can be a scalar array or a one dimensional array providing a single value
-for each PFT. This then calculates a single estimate at the given size for each stem.
+A `StemTraits` instance can be created directly by providing arrays for each trait, but is
+more easily created from a `Flora` object by providing a list of PFT names:
 
 ```{code-cell}
-# Calculate a single prediction
-single_allometry = StemAllometry(stem_traits=flora, at_dbh=np.array([0.1, 0.1, 0.1]))
-```
+# Get stem traits for a range of stems
+stem_pfts = ["short", "short", "short", "medium", "medium", "tall"]
+stem_traits = flora.get_stem_traits(pft_names=stem_pfts)
 
-We can display those predictions as a `pandas.DataFrame`:
-
-```{code-cell}
-pd.DataFrame(
-    {k: getattr(single_allometry, k) for k in single_allometry.allometry_attrs}
-)
-```
-
-However, the DBH values can also be a column array (an `N` x 1 array). In this case, the
-predictions are made at each DBH value for each PFT and the allometry attributes with
-predictions arranged with each PFT as a column and each DBH prediction as a row. This
-makes them convenient to plot using `matplotlib`.
-
-```{code-cell}
-# Column array of DBH values from 0 to 1.6 metres
-dbh_col = np.arange(0, 1.6, 0.01)[:, None]
-# Get the predictions
-allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_col)
-```
-
-The code below shows how to use the returned allometries to generate a plot of the
-scaling relationships across all of the PFTs in a `Flora` instance.
-
-```{code-cell}
-fig, axes = plt.subplots(ncols=2, nrows=4, sharex=True, figsize=(10, 10))
-
-plot_details = [
-    ("stem_height", "Stem height (m)"),
-    ("crown_area", "Crown area (m2)"),
-    ("crown_fraction", "Crown fraction (-)"),
-    ("stem_mass", "Stem mass (kg)"),
-    ("foliage_mass", "Foliage mass (kg)"),
-    ("sapwood_mass", "Sapwood mass (kg)"),
-    ("crown_r0", "Crown scaling factor (-)"),
-    ("crown_z_max", "Height of maximum\ncrown radius (m)"),
-]
-
-for ax, (var, ylab) in zip(axes.flatten(), plot_details):
-    ax.plot(dbh_col, getattr(allometries, var), label=flora.name)
-    ax.set_xlabel("Diameter at breast height (m)")
-    ax.set_ylabel(ylab)
-
-    if var == "sapwood_mass":
-        ax.legend(frameon=False)
-```
-
-## Productivity allocation
-
-The T Model also predicts how potential GPP will be allocated to respiration, turnover
-and growth for stems with a given PFT and allometry. Again, a single value can be
-provided to get a single estimate of the allocation model for each stem:
-
-```{code-cell}
-single_allocation = StemAllocation(
-    stem_traits=flora, stem_allometry=single_allometry, at_potential_gpp=np.array([55])
-)
-single_allocation
-```
-
-```{code-cell}
-pd.DataFrame(
-    {k: getattr(single_allocation, k) for k in single_allocation.allocation_attrs}
-)
-```
-
-Using a column array of potential GPP values can be used predict multiple estimates of
-allocation per stem. In the first example, the code takes the allometric predictions
-from above and calculates the GPP allocation for stems of varying size with the same
-potential GPP:
-
-```{code-cell}
-potential_gpp = np.repeat(5, dbh_col.size)[:, None]
-allocation = StemAllocation(
-    stem_traits=flora, stem_allometry=allometries, at_potential_gpp=potential_gpp
-)
-```
-
-```{code-cell}
-fig, axes = plt.subplots(ncols=2, nrows=5, sharex=True, figsize=(10, 12))
-
-plot_details = [
-    ("whole_crown_gpp", "whole_crown_gpp"),
-    ("sapwood_respiration", "sapwood_respiration"),
-    ("foliar_respiration", "foliar_respiration"),
-    ("fine_root_respiration", "fine_root_respiration"),
-    ("npp", "npp"),
-    ("turnover", "turnover"),
-    ("delta_dbh", "delta_dbh"),
-    ("delta_stem_mass", "delta_stem_mass"),
-    ("delta_foliage_mass", "delta_foliage_mass"),
-]
-
-axes = axes.flatten()
-
-for ax, (var, ylab) in zip(axes, plot_details):
-    ax.plot(dbh_col, getattr(allocation, var), label=flora.name)
-    ax.set_xlabel("Diameter at breast height (m)")
-    ax.set_ylabel(ylab)
-
-    if var == "whole_crown_gpp":
-        ax.legend(frameon=False)
-
-# Delete unused panel in 5 x 2 grid
-fig.delaxes(axes[-1])
-```
-
-An alternative calculation is to make allocation predictions for varying potential GPP
-for constant allometries:
-
-```{code-cell}
-# Column array of DBH values from 0 to 1.6 metres
-dbh_constant = np.repeat(0.2, 50)[:, None]
-# Get the allometric predictions
-constant_allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_constant)
-
-potential_gpp_varying = np.linspace(1, 10, num=50)[:, None]
-allocation_2 = StemAllocation(
-    stem_traits=flora,
-    stem_allometry=constant_allometries,
-    at_potential_gpp=potential_gpp_varying,
-)
-```
-
-```{code-cell}
-fig, axes = plt.subplots(ncols=2, nrows=5, sharex=True, figsize=(10, 12))
-
-axes = axes.flatten()
-
-for ax, (var, ylab) in zip(axes, plot_details):
-    ax.plot(potential_gpp_varying, getattr(allocation_2, var), label=flora.name)
-    ax.set_xlabel("Potential GPP")
-    ax.set_ylabel(ylab)
-
-    if var == "whole_crown_gpp":
-        ax.legend(frameon=False)
-
-# Delete unused panel in 5 x 2 grid
-fig.delaxes(axes[-1])
-```
-
-```{code-cell}
-
+# Show the repeated values
+stem_traits.h_max
 ```

--- a/docs/source/users/demography/module_overview.md
+++ b/docs/source/users/demography/module_overview.md
@@ -13,4 +13,15 @@ kernelspec:
 
 # The demography module
 
-This is placeholder text for a broader introduction to the demography module.
+The functionality of the demography module is split into the following submodules
+
+* The [`flora` module](./flora.md) that defines the set of plant functional traits used
+  in demographic modelling and the classes used to represent those traits.
+* The [`t_model` module](./t_model.md) module that implements the allometric and
+  allocation equations of the T Model {cite}`Li:2014bc`.
+* The [`crown` module](./crown.md) that implements a three dimensional model of crown
+  shape taken from the Plant-FATE model {cite}`joshi:2022a`.
+* The [`community` module](./community.md) that implements a plant community model using
+  size-structured cohorts.
+* The [`canopy` module](./canopy.md) that generates a model of the canopy structure for
+  a community, based on the Perfect Plasticity Approximation model :cite:`purves:2008a`.

--- a/docs/source/users/demography/module_overview.md
+++ b/docs/source/users/demography/module_overview.md
@@ -24,4 +24,4 @@ The functionality of the demography module is split into the following submodule
 * The [`community` module](./community.md) that implements a plant community model using
   size-structured cohorts.
 * The [`canopy` module](./canopy.md) that generates a model of the canopy structure for
-  a community, based on the Perfect Plasticity Approximation model :cite:`purves:2008a`.
+  a community, based on the Perfect Plasticity Approximation model {cite}`purves:2008a`.

--- a/docs/source/users/demography/module_overview.md
+++ b/docs/source/users/demography/module_overview.md
@@ -1,0 +1,16 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# The demography module
+
+This is placeholder text for a broader introduction to the demography module.

--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -1,0 +1,211 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# The T Model module
+
+The T Model {cite}`Li:2014bc` provides a model of both:
+
+* stem allometry, given a set of [stem traits](./flora.md) for a plant functional type
+  (PFT), and
+* a carbon allocation model, given stem allometry and potential GPP.
+
+```{code-cell}
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+
+from pyrealm.demography.flora import PlantFunctionalType, Flora
+from pyrealm.demography.t_model_functions import StemAllocation, StemAllometry
+```
+
+To generate predictions under the T Model, we need a Flora object providing the
+[trait values](./flora.md) for each of the PFTsto be modelled:
+
+```{code-cell}
+# Three PFTS
+short_pft = PlantFunctionalType(name="short", h_max=10)
+medium_pft = PlantFunctionalType(name="medium", h_max=20)
+tall_pft = PlantFunctionalType(name="tall", h_max=30)
+
+# Combine into a Flora instance
+flora = Flora([short_pft, medium_pft, tall_pft])
+```
+
+## Stem allometry
+
+We can visualise how the stem size, canopy size and various masses of PFTs change with
+stem diameter by using the {class}`~pyrealm.demography.t_model_functions.StemAllometry`
+class. Creating a `StemAllometry` instance needs an existing `Flora` instance and an
+array of values for diameter at breast height (DBH, metres). The returned class contains
+the predictions of the T Model for:
+
+* Stem height (`stem_height`, m),
+* Crown area (`crown_area`, m2),
+* Crown fraction (`crown_fraction`, -),
+* Stem mass (`stem_mass`, kg),
+* Foliage mass (`foliage_mass`, kg),
+* Sapwood mass (`sapwood_mass`, kg),
+* Crown radius scaling factor (`crown_r0`, -), and
+* Height of maximum crown radius (`crown_z_max`, m).
+
+The DBH input can be a scalar array or a one dimensional array providing a single value
+for each PFT. This then calculates a single estimate at the given size for each stem.
+
+```{code-cell}
+# Calculate a single prediction
+single_allometry = StemAllometry(stem_traits=flora, at_dbh=np.array([0.1, 0.1, 0.1]))
+```
+
+We can display those predictions as a `pandas.DataFrame`:
+
+```{code-cell}
+pd.DataFrame(
+    {k: getattr(single_allometry, k) for k in single_allometry.allometry_attrs}
+)
+```
+
+However, the DBH values can also be a column array (an `N` x 1 array). In this case, the
+predictions are made at each DBH value for each PFT and the allometry attributes with
+predictions arranged with each PFT as a column and each DBH prediction as a row. This
+makes them convenient to plot using `matplotlib`.
+
+```{code-cell}
+# Column array of DBH values from 0 to 1.6 metres
+dbh_col = np.arange(0, 1.6, 0.01)[:, None]
+# Get the predictions
+allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_col)
+```
+
+The code below shows how to use the returned allometries to generate a plot of the
+scaling relationships across all of the PFTs in a `Flora` instance.
+
+```{code-cell}
+fig, axes = plt.subplots(ncols=2, nrows=4, sharex=True, figsize=(10, 10))
+
+plot_details = [
+    ("stem_height", "Stem height (m)"),
+    ("crown_area", "Crown area (m2)"),
+    ("crown_fraction", "Crown fraction (-)"),
+    ("stem_mass", "Stem mass (kg)"),
+    ("foliage_mass", "Foliage mass (kg)"),
+    ("sapwood_mass", "Sapwood mass (kg)"),
+    ("crown_r0", "Crown scaling factor (-)"),
+    ("crown_z_max", "Height of maximum\ncrown radius (m)"),
+]
+
+for ax, (var, ylab) in zip(axes.flatten(), plot_details):
+    ax.plot(dbh_col, getattr(allometries, var), label=flora.name)
+    ax.set_xlabel("Diameter at breast height (m)")
+    ax.set_ylabel(ylab)
+
+    if var == "sapwood_mass":
+        ax.legend(frameon=False)
+```
+
+## Productivity allocation
+
+The T Model also predicts how potential GPP will be allocated to respiration, turnover
+and growth for stems with a given PFT and allometry. Again, a single value can be
+provided to get a single estimate of the allocation model for each stem:
+
+```{code-cell}
+single_allocation = StemAllocation(
+    stem_traits=flora, stem_allometry=single_allometry, at_potential_gpp=np.array([55])
+)
+single_allocation
+```
+
+```{code-cell}
+pd.DataFrame(
+    {k: getattr(single_allocation, k) for k in single_allocation.allocation_attrs}
+)
+```
+
+Using a column array of potential GPP values can be used predict multiple estimates of
+allocation per stem. In the first example, the code takes the allometric predictions
+from above and calculates the GPP allocation for stems of varying size with the same
+potential GPP:
+
+```{code-cell}
+potential_gpp = np.repeat(5, dbh_col.size)[:, None]
+allocation = StemAllocation(
+    stem_traits=flora, stem_allometry=allometries, at_potential_gpp=potential_gpp
+)
+```
+
+```{code-cell}
+fig, axes = plt.subplots(ncols=2, nrows=5, sharex=True, figsize=(10, 12))
+
+plot_details = [
+    ("whole_crown_gpp", "whole_crown_gpp"),
+    ("sapwood_respiration", "sapwood_respiration"),
+    ("foliar_respiration", "foliar_respiration"),
+    ("fine_root_respiration", "fine_root_respiration"),
+    ("npp", "npp"),
+    ("turnover", "turnover"),
+    ("delta_dbh", "delta_dbh"),
+    ("delta_stem_mass", "delta_stem_mass"),
+    ("delta_foliage_mass", "delta_foliage_mass"),
+]
+
+axes = axes.flatten()
+
+for ax, (var, ylab) in zip(axes, plot_details):
+    ax.plot(dbh_col, getattr(allocation, var), label=flora.name)
+    ax.set_xlabel("Diameter at breast height (m)")
+    ax.set_ylabel(ylab)
+
+    if var == "whole_crown_gpp":
+        ax.legend(frameon=False)
+
+# Delete unused panel in 5 x 2 grid
+fig.delaxes(axes[-1])
+```
+
+An alternative calculation is to make allocation predictions for varying potential GPP
+for constant allometries:
+
+```{code-cell}
+# Column array of DBH values from 0 to 1.6 metres
+dbh_constant = np.repeat(0.2, 50)[:, None]
+# Get the allometric predictions
+constant_allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_constant)
+
+potential_gpp_varying = np.linspace(1, 10, num=50)[:, None]
+allocation_2 = StemAllocation(
+    stem_traits=flora,
+    stem_allometry=constant_allometries,
+    at_potential_gpp=potential_gpp_varying,
+)
+```
+
+```{code-cell}
+fig, axes = plt.subplots(ncols=2, nrows=5, sharex=True, figsize=(10, 12))
+
+axes = axes.flatten()
+
+for ax, (var, ylab) in zip(axes, plot_details):
+    ax.plot(potential_gpp_varying, getattr(allocation_2, var), label=flora.name)
+    ax.set_xlabel("Potential GPP")
+    ax.set_ylabel(ylab)
+
+    if var == "whole_crown_gpp":
+        ax.legend(frameon=False)
+
+# Delete unused panel in 5 x 2 grid
+fig.delaxes(axes[-1])
+```
+
+```{code-cell}
+
+```

--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -131,7 +131,7 @@ pd.DataFrame(
 )
 ```
 
-Using a column array of potential GPP values can be used predict multiple estimates of
+Using a column array of potential GPP values can be used to predict multiple estimates of
 allocation per stem. In the first example, the code takes the allometric predictions
 from above and calculates the GPP allocation for stems of varying size with the same
 potential GPP:

--- a/docs/source/users/tmodel/canopy.md
+++ b/docs/source/users/tmodel/canopy.md
@@ -1,0 +1,677 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Canopy model
+
+This notebook walks through the steps in generating the canopy model as (hopefully) used
+in Plant-FATE.
+
+## The T Model
+
+The T Model provides a numerical description of how tree geometry scales with stem
+diameter, and an allocation model of how GPP predicts changes in stem diameter.
+
+The implementation in `pyrealm` provides a class representing a particular plant
+functional type, using a set of traits. The code below creates a PFT with the default
+set of trait values.
+
+```{warning}
+This sketch:
+
+* Assumes a single individual of each stem diameter, but in practice
+  we are going to want to include a number of individuals to capture cohorts.
+* Assumes a single PFT, where we will need to provide a mixed community.
+* Consequently handles forest inventory properties in a muddled way: we will
+  likely package all of the stem data into a single class, probably a community
+  object.
+```
+
+```{code-cell}
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.optimize import root_scalar
+
+from pyrealm.tmodel import TTree
+
+np.set_printoptions(precision=3)
+
+# Plant functional type with default parameterization
+pft = TTree(diameters=np.array([0.1, 0.15, 0.2, 0.25, 0.38, 0.4, 1.0]))
+pft.traits
+```
+
+The scaling of a set of trees is automatically calculated using the initial diameters to
+the `TTree` instance. This automatically calculates the other dimensions, such as
+height, using the underlying scaling equations of the T Model.
+
+```{code-cell}
+pft.height
+```
+
+```{code-cell}
+:lines_to_next_cell: 2
+
+pft.crown_area
+```
+
++++ {"lines_to_next_cell": 2}
+
+### Crown shape
+
+Jaideep's extension of the T Model adds a crown shape model, driven by two parameters
+($m$ and $n$) that provide a very flexible description of the vertical crown profile.
+These are used to derive two further invariant parameters: $q_m$ scales the canopy
+radius to match the predictions of crown area under the T model and $p_{zm}$ is the
+proportion of the total stem height at which the maximum crown radius occurs. Both these
+values are constant for a plant functional type.
+
+$$
+\begin{align}
+q_m &= m n \left(\dfrac{n-1}{m n -1}\right)^ {1 - \tfrac{1}{n}}
+    \left(\dfrac{\left(m-1\right) n}{m n -1}\right)^ {m-1} \\[8pt]
+p_{zm} &= \left(\dfrac{n-1}{m n -1}\right)^ {\tfrac{1}{n}}
+\end{align}
+$$
+
+For individual stems, with expected height $H$ and crown area $A_c$, we can then
+estimate:
+
+* the height $z_m$ at which the maximum crown radius $r_m$ is found, and
+* a slope $r_0$ that scales the relative canopy radius so that the $r_m$ matches
+  the allometric prediction of $A_c$ from the T Model.
+
+$$
+\begin{align}
+z_m &= H p_{zm}\\[8pt]
+r_0 &= \frac{1}{q_m}\sqrt{\frac{A_c}{\pi}}
+\end{align}
+$$
+
+```{code-cell}
+:lines_to_next_cell: 2
+
+def calculate_qm(m, n):
+
+    # Constant q_m
+    return (
+        m
+        * n
+        * ((n - 1) / (m * n - 1)) ** (1 - 1 / n)
+        * (((m - 1) * n) / (m * n - 1)) ** (m - 1)
+    )
+
+
+def calculate_stem_canopy_factors(pft, m, n):
+
+    # Height of maximum crown radius
+    zm = pft.height * ((n - 1) / (m * n - 1)) ** (1 / n)
+
+    # Slope to give Ac at zm
+    r0 = 1 / qm * np.sqrt(pft.crown_area / np.pi)
+
+    return zm, r0
+
+
+# Shape parameters for a fairly top heavy crown profile
+m = 2
+n = 5
+qm = calculate_qm(m=m, n=n)
+zm, r0 = calculate_stem_canopy_factors(pft=pft, m=m, n=n)
+
+print("qm = ", np.round(qm, 4))
+print("zm = ", zm)
+print("r0 = ", r0)
+```
+
++++ {"lines_to_next_cell": 2}
+
+The following functions then provide the value at height $z$ of relative $q(z)$ and
+actual $r(z)$ canopy radius:
+
+$$
+\begin{align}
+q(z) &= m n \left(\dfrac{z}{H}\right) ^ {n -1}
+    \left( 1 - \left(\dfrac{z}{H}\right) ^ n \right)^{m-1}\\[8pt]
+r(z) &= r_0 \; q(z)
+\end{align}
+$$
+
+```{code-cell}
+def calculate_relative_canopy_radius_at_z(z, H, m, n):
+    """Calculate q(z)"""
+
+    z_over_H = z / H
+
+    return m * n * z_over_H ** (n - 1) * (1 - z_over_H**n) ** (m - 1)
+```
+
+```{code-cell}
+# Validate that zm and r0 generate the predicted maximum crown area
+q_zm = calculate_relative_canopy_radius_at_z(zm, pft.height, m, n)
+rm = r0 * q_zm
+print("rm = ", rm)
+```
+
+```{code-cell}
+np.allclose(rm**2 * np.pi, pft.crown_area)
+```
+
+Vertical crown radius profiles can now be calculated for each stem:
+
+```{code-cell}
+# Create an interpolation from ground to maximum stem height, with 5 cm resolution.
+# Also append a set of values _fractionally_ less than the exact height  of stems
+# so that the height at the top of each stem is included but to avoid floating
+# point issues with exact heights.
+
+zres = 0.05
+z = np.arange(0, pft.height.max() + 1, zres)
+z = np.sort(np.concatenate([z, pft.height - 0.00001]))
+
+# Convert the heights into a column matrix to broadcast against the stems
+# and then calculate r(z) = r0 * q(z)
+rz = r0 * calculate_relative_canopy_radius_at_z(z[:, None], pft.height, m, n)
+
+# When z > H, rz < 0, so set radius to 0 where rz < 0
+rz[np.where(rz < 0)] = 0
+
+np.cumsum(np.convolve(rm, np.ones(2), "valid") + 0.1)
+```
+
+Those can be plotted out to show the vertical crown radius profiles
+
+```{code-cell}
+# Separate the stems along the x axis for plotting
+stem_x = np.concatenate(
+    [np.array([0]), np.cumsum(np.convolve(rm, np.ones(2), "valid") + 0.4)]
+)
+
+# Get the canopy sections above and below zm
+rz_above_zm = np.where(np.logical_and(rz > 0, np.greater.outer(z, zm)), rz, np.nan)
+rz_below_zm = np.where(np.logical_and(rz > 0, np.less_equal.outer(z, zm)), rz, np.nan)
+
+# Plot the canopy parts
+plt.plot(stem_x + rz_below_zm, z, color="khaki")
+plt.plot(stem_x - rz_below_zm, z, color="khaki")
+plt.plot(stem_x + rz_above_zm, z, color="forestgreen")
+plt.plot(stem_x - rz_above_zm, z, color="forestgreen")
+
+# Add the maximum radius
+plt.plot(np.vstack((stem_x - rm, stem_x + rm)), np.vstack((zm, zm)), color="firebrick")
+
+# Plot the stem centre lines
+plt.vlines(stem_x, 0, pft.height, linestyles="-", color="grey")
+
+plt.gca().set_aspect("equal")
+```
+
+## Canopy structure
+
+The canopy structure model uses the perfect plasticity approximation (PPA), which
+assumes that plants can arrange their canopies to fill the available space $A$.
+It takes the **projected area of stems** $Ap(z)$ within the canopy and finds the heights
+at which each canopy layer closes ($z^*_l$ for $l = 1, 2, 3 ...$) where the total projected
+area of the canopy equals $lA$.
+
+### Canopy projected area
+
+The projected area $A_p$ for a stem with height $H$, a maximum crown area $A_c$ at a
+height $z_m$ and $m$, $n$ and $q_m$ for the associated plant functional type is
+
+$$
+A_p(z)=
+\begin{cases}
+A_c, & z \le z_m \\
+A_c \left(\dfrac{q(z)}{q_m}\right)^2, & H > z > z_m \\
+0, & z > H
+\end{cases}
+$$
+
+```{code-cell}
+Stems = float | np.ndarray
+
+
+def calculate_projected_area(
+    z: float,
+    pft,
+    m: Stems,
+    n: Stems,
+    qm: Stems,
+    zm: Stems,
+) -> np.ndarray:
+    """Calculate projected crown area above a given height.
+
+    This function takes PFT specific parameters (shape parameters) and stem specific
+    sizes and estimates the projected crown area above a given height $z$. The inputs
+    can either be scalars describing a single stem or arrays representing a community
+    of stems. If only a single PFT is being modelled then `m`, `n`, `qm` and `fg` can
+    be scalars with arrays `H`, `Ac` and `zm` giving the sizes of stems within that
+    PFT.
+
+    Args:
+        z: Canopy height
+        m, n, qm : PFT specific shape parameters
+        pft, qm, zm: stem data
+
+    """
+
+    # Calculate q(z)
+    qz = calculate_relative_canopy_radius_at_z(z, pft.height, m, n)
+
+    # Calculate Ap given z > zm
+    Ap = pft.crown_area * (qz / qm) ** 2
+    # Set Ap = Ac where z <= zm
+    Ap = np.where(z <= zm, pft.crown_area, Ap)
+    # Set Ap = 0 where z > H
+    Ap = np.where(z > pft.height, 0, Ap)
+
+    return Ap
+```
+
+The code below calculates the projected crown area for each stem and then plots the
+vertical profile for individual stems and across the community.
+
+```{code-cell}
+:lines_to_next_cell: 2
+
+# Calculate the projected area for each stem
+Ap_z = calculate_projected_area(z=z[:, None], pft=pft, m=m, n=n, qm=qm, zm=zm)
+
+# Plot the calculated values for each stem and across the community
+fig, (ax1, ax2) = plt.subplots(1, 2, sharey=True, figsize=(10, 5))
+
+# Plot the individual stem projected area
+ax1.set_ylabel("Height above ground ($z$, m)")
+ax1.plot(Ap_z, z)
+ax1.set_xlabel("Stem $A_p(z)$ (m2)")
+
+# Plot the individual stem projected area
+ax2.plot(np.nansum(Ap_z, axis=1), z)
+ax2.set_xlabel("Total community $A_p(z)$ (m2)")
+
+plt.tight_layout()
+```
+
++++ {"lines_to_next_cell": 2}
+
+### Canopy closure and canopy gap fraction
+
+The total cumulative projected area shown above is modified by a community-level
+**canopy gap fraction** ($f_G$) that captures the overall proportion of the canopy area
+that is left unfilled by canopy. This gap fraction, capturing processes such as crown
+shyness, describes the proportion of open sky visible from the forest floor.
+
+The definition of the height of canopy layer closure ($z^*_l$) for a given canopy
+layer $l = 1, ..., l_m$ is then:
+
+$$
+\sum_1^{N_s}{ A_p(z^*_l)} = l A(1 - f_G)
+$$
+
+This can be found numerically using a root solver as:
+
+$$
+\sum_1^{N_s}{ A_p(z^*_l)} - l A(1 - f_G) = 0
+$$
+
+The total number of layers $l_m$ in a canopy, where the final layer may not be fully closed,
+can be found given the total crown area across stems as:
+
+$$
+l_m = \left\lceil \frac{\sum_1^{N_s}{ A_c}}{ A(1 - f_G)}\right\rceil
+$$
+
+```{code-cell}
+def solve_canopy_closure_height(
+    z: float,
+    l: int,
+    A: float,
+    fG: float,
+    m: Stems,
+    n: Stems,
+    qm: Stems,
+    pft: Stems,
+    zm: Stems,
+) -> np.ndarray:
+    """Solver function for canopy closure height.
+
+    This function returns the difference between the total community projected area
+    at a height $z$ and the total available canopy space for canopy layer $l$, given
+    the community gap fraction for a given height. It is used with a root solver to
+    find canopy layer closure heights $z^*_l* for a community.
+
+    Args:
+        m, n, qm : PFT specific shape parameters
+        H, Ac, zm: stem specific sizes
+        A, l: cell area and layer index
+        fG: community gap fraction
+    """
+
+    # Calculate Ap(z)
+    Ap_z = calculate_projected_area(z=z, pft=pft, m=m, n=n, qm=qm, zm=zm)
+
+    # Return the difference between the projected area and the available space
+    return Ap_z.sum() - (A * l) * (1 - fG)
+
+
+def calculate_canopy_heights(
+    A: float,
+    fG: float,
+    m: Stems,
+    n: Stems,
+    qm: Stems,
+    pft,
+    zm: Stems,
+):
+
+    # Calculate the number of layers
+    total_community_ca = pft.crown_area.sum()
+    n_layers = int(np.ceil(total_community_ca / (A * (1 - fG))))
+
+    # Data store for z*
+    z_star = np.zeros(n_layers)
+
+    # Loop over the layers TODO - edge case of completely filled final layer
+    for lyr in np.arange(n_layers - 1):
+        z_star[lyr] = root_scalar(
+            solve_canopy_closure_height,
+            args=(lyr + 1, A, fG, m, n, qm, pft, zm),
+            bracket=(0, pft.height.max()),
+        ).root
+
+    return z_star
+```
+
+The example below calculates the projected crown area above ground level for the example
+stems. These should be identical to the crown area of the stems.
+
+```{code-cell}
+# Set the total available canopy space and community gap fraction
+canopy_area = 32
+community_gap_fraction = 2 / 32
+
+z_star = calculate_canopy_heights(
+    A=canopy_area, fG=community_gap_fraction, m=m, n=n, qm=qm, pft=pft, zm=zm
+)
+
+print("z_star = ", z_star)
+```
+
+We can now plot the canopy stems alongside the community $A_p(z)$ profile, and
+superimpose the calculated $z^*_l$ values and the cumulative canopy area for each layer
+to confirm that the calculated values coincide with the profile. Note here that the
+total area at each closed layer height is omitting the community gap fraction.
+
+```{code-cell}
+community_Ap_z = np.nansum(Ap_z, axis=1)
+
+fig, (ax1, ax2) = plt.subplots(1, 2, sharey=True, figsize=(10, 5))
+
+zcol = "red"
+
+# Plot the canopy parts
+ax1.plot(stem_x + rz_below_zm, z, color="khaki")
+ax1.plot(stem_x - rz_below_zm, z, color="khaki")
+ax1.plot(stem_x + rz_above_zm, z, color="forestgreen")
+ax1.plot(stem_x - rz_above_zm, z, color="forestgreen")
+
+# Add the maximum radius
+ax1.plot(np.vstack((stem_x - rm, stem_x + rm)), np.vstack((zm, zm)), color="firebrick")
+
+# Plot the stem centre lines
+ax1.vlines(stem_x, 0, pft.height, linestyles="-", color="grey")
+
+ax1.set_ylabel("Height above ground ($z$, m)")
+ax1.set_xlabel("Arbitrary stem position")
+ax1.hlines(z_star, 0, (stem_x + rm).max(), color=zcol, linewidth=0.5)
+
+# Plot the projected community crown area by height along with the heights
+# at which different canopy layers close
+ax2.hlines(z_star, 0, community_Ap_z.max(), color=zcol, linewidth=0.5)
+ax2.vlines(
+    canopy_area * np.arange(1, len(z_star)) * (1 - community_gap_fraction),
+    0,
+    pft.height.max(),
+    color=zcol,
+    linewidth=0.5,
+)
+
+ax2.plot(community_Ap_z, z)
+ax2.set_xlabel("Projected crown area above height $z$ ($A_p(z)$, m2)")
+
+# Add z* values on the righthand axis
+ax3 = ax2.twinx()
+
+
+def z_star_labels(X):
+    return [f"$z^*_{l + 1}$ = {z:.2f}" for l, z in enumerate(X)]
+
+
+ax3.set_ylim(ax2.get_ylim())
+ax3.set_yticks(z_star)
+ax3.set_yticklabels(z_star_labels(z_star))
+
+ax4 = ax2.twiny()
+
+# Add canopy layer closure areas on top axis
+cum_area = np.arange(1, len(z_star)) * canopy_area * (1 - community_gap_fraction)
+
+
+def cum_area_labels(X):
+    return [f"$A_{l + 1}$ = {z:.1f}" for l, z in enumerate(X)]
+
+
+ax4.set_xlim(ax2.get_xlim())
+ax4.set_xticks(cum_area)
+ax4.set_xticklabels(cum_area_labels(cum_area))
+
+plt.tight_layout()
+```
+
+The projected area from individual stems to each canopy layer can then be calculated at
+$z^*_l$ and hence the projected area of canopy **within each layer**.
+
+```{code-cell}
+# Calculate the canopy area above z_star for each stem
+Ap_z_star = calculate_projected_area(z=z_star[:, None], pft=pft, m=m, n=n, qm=qm, zm=zm)
+
+print(Ap_z_star)
+```
+
+```{code-cell}
+:lines_to_next_cell: 2
+
+# Calculate the contribution _within_ each layer per stem
+Ap_within_layer = np.diff(Ap_z_star, axis=0, prepend=0)
+
+print(Ap_within_layer)
+```
+
++++ {"lines_to_next_cell": 2}
+
+### Leaf area within canopy layers
+
+The projected area occupied by leaves at a given height $\tilde{A}_{cp}(z)$ is
+needed to calculate light transmission through those layers. This differs from the
+projected area $A_p(z)$ because, although a tree occupies an area in the canopy
+following the PPA, a **crown gap fraction** ($f_g$) reduces the actual leaf area
+at a given height $z$.
+
+The crown gap fraction does not affect the overall projected canopy area at ground
+level or the community gap fraction: the amount of clear sky at ground level is
+governed purely by $f_G$. Instead it models how leaf gaps in the upper canopy are
+filled by leaf area at lower heights. It captures the vertical distribution of
+leaf area within the canopy: a higher $f_g$ will give fewer leaves at the top of
+the canopy and more leaves further down within the canopy.
+
+The calculation of $\tilde{A}_{cp}(z)$ is defined as:
+
+$$
+\tilde{A}_{cp}(z)=
+\begin{cases}
+0, & z \gt H \\
+A_c \left(\dfrac{q(z)}{q_m}\right)^2 \left(1 - f_g\right), & H \gt z \gt z_m \\
+Ac - A_c \left(\dfrac{q(z)}{q_m}\right)^2 f_g, & zm \gt z
+\end{cases}
+$$
+
+The function below calculates $\tilde{A}_{cp}(z)$.
+
+```{code-cell}
+def calculate_leaf_area(
+    z: float,
+    fg: float,
+    pft,
+    m: Stems,
+    n: Stems,
+    qm: Stems,
+    zm: Stems,
+) -> np.ndarray:
+    """Calculate leaf area above a given height.
+
+    This function takes PFT specific parameters (shape parameters) and stem specific
+    sizes and estimates the projected crown area above a given height $z$. The inputs
+    can either be scalars describing a single stem or arrays representing a community
+    of stems. If only a single PFT is being modelled then `m`, `n`, `qm` and `fg` can
+    be scalars with arrays `H`, `Ac` and `zm` giving the sizes of stems within that
+    PFT.
+
+    Args:
+        z: Canopy height
+        fg: crown gap fraction
+        m, n, qm : PFT specific shape parameters
+        pft, qm, zm: stem data
+    """
+
+    # Calculate q(z)
+    qz = calculate_relative_canopy_radius_at_z(z, pft.height, m, n)
+
+    # Calculate Ac term
+    Ac_term = pft.crown_area * (qz / qm) ** 2
+    # Set Acp either side of zm
+    Acp = np.where(z <= zm, pft.crown_area - Ac_term * fg, Ac_term * (1 - fg))
+    # Set Ap = 0 where z > H
+    Acp = np.where(z > pft.height, 0, Acp)
+
+    return Acp
+```
+
+The plot below shows how the vertical leaf area profile for the community changes for
+different values of $f_g$. When $f_g = 0$, then $A_cp(z) = A_p(z)$ (red line) because
+there are no crown gaps and hence all of the leaf area is within the crown surface. As
+$f_g \to 1$, more of the leaf area is displaced deeper into the canopy, leaves in the
+lower crown intercepting light coming through holes in the upper canopy.
+
+```{code-cell}
+fig, ax1 = plt.subplots(1, 1, figsize=(6, 5))
+
+for fg in np.arange(0, 1.01, 0.05):
+
+    if fg == 0:
+        color = "red"
+        label = "$f_g = 0$"
+        lwd = 0.5
+    elif fg == 1:
+        color = "blue"
+        label = "$f_g = 1$"
+        lwd = 0.5
+    else:
+        color = "black"
+        label = None
+        lwd = 0.25
+
+    Acp_z = calculate_leaf_area(z=z[:, None], fg=fg, pft=pft, m=m, n=n, qm=qm, zm=zm)
+    ax1.plot(np.nansum(Acp_z, axis=1), z, color=color, linewidth=lwd, label=label)
+
+ax1.set_xlabel(r"Projected leaf area above height $z$ ($\tilde{A}_{cp}(z)$, m2)")
+ax1.legend(frameon=False)
+```
+
+We can now calculate the crown area occupied by leaves above the height of each closed
+layer $z^*_l$:
+
+```{code-cell}
+# Calculate the leaf area above z_star for each stem
+crown_gap_fraction = 0.05
+Acp_z_star = calculate_leaf_area(
+    z=z_star[:, None], fg=crown_gap_fraction, pft=pft, m=m, n=n, qm=qm, zm=zm
+)
+
+print(Acp_z_star)
+```
+
+And from that, the area occupied by leaves **within each layer**. These values are
+similar to the projected crown area within layers (`Ap_within_layer`, above) but
+leaf area is displaced into lower layers because $f_g > 0$.
+
+```{code-cell}
+# Calculate the contribution _within_ each layer per stem
+Acp_within_layer = np.diff(Acp_z_star, axis=0, prepend=0)
+
+print(Acp_within_layer)
+```
+
+### Light transmission through the canopy
+
+Now we can use the leaf area by layer and the Beer-Lambert equation to calculate light
+attenuation through the canopy layers.
+
+$f_{abs} = 1 - e ^ {-kL}$,
+
+where $k$ is the light extinction coefficient ($k$) and $L$ is the leaf area index
+(LAI). The LAI can be calculated for each stem and layer:
+
+```{code-cell}
+LAI = Acp_within_layer / canopy_area
+print(LAI)
+```
+
+This can be used to calculate the LAI of individual stems but also the LAI of each layer
+in the canopy:
+
+```{code-cell}
+LAI_stem = LAI.sum(axis=0)
+LAI_layer = LAI.sum(axis=1)
+
+print("LAI stem = ", LAI_stem)
+print("LAI layer = ", LAI_layer)
+```
+
+The layer LAI values can now be used to calculate the light transmission of each layer and
+hence the cumulative light extinction profile through the canopy.
+
+```{code-cell}
+f_abs = 1 - np.exp(-pft.traits.par_ext * LAI_layer)
+ext = np.cumprod(f_abs)
+
+print("f_abs = ", f_abs)
+print("extinction = ", ext)
+```
+
+One issue that needs to be resolved is that the T Model implementation in `pyrealm`
+follows the original implementation of the T Model in having LAI as a fixed trait of
+a given plant functional type, so is constant for all stems of that PFT.
+
+```{code-cell}
+print("f_abs = ", (1 - np.exp(-pft.traits.par_ext * pft.traits.lai)))
+```
+
+## Things to worry about later
+
+Herbivory - leaf fall (transmission increases, truncate at 0, replace from NSCs) vs leaf
+turnover (transmission constant, increased GPP penalty)
+
+Leaf area dynamics in PlantFATE - acclimation to herbivory and transitory decreases in
+transimission, need non-structural carbohydrates  to recover from total defoliation.
+
+Leaf economics.

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -391,6 +391,12 @@ class CrownProfile:
     projected_leaf_area: NDArray[np.float32] = field(init=False)
     """An array of the projected leaf area of stems at z heights"""
 
+    # Information attributes
+    _n_pred: int = field(init=False)
+    """The number of predictions per stem."""
+    _n_stems: int = field(init=False)
+    """The number of stems."""
+
     def __post_init__(
         self,
         stem_traits: StemTraits | Flora,
@@ -430,4 +436,19 @@ class CrownProfile:
             crown_area=stem_allometry.crown_area,
             stem_height=stem_allometry.stem_height,
             z_max=stem_allometry.crown_z_max,
+        )
+
+        # Set the number of observations per stem (one if dbh is 1D, otherwise size of
+        # the first axis)
+        if self.relative_crown_radius.ndim == 1:
+            self._n_pred = 1
+        else:
+            self._n_pred = self.relative_crown_radius.shape[0]
+
+        self._n_stems = stem_traits._n_stems
+
+    def __repr__(self) -> str:
+        return (
+            f"CrownProfile: Prediction for {self._n_stems} stems "
+            f"at {self._n_pred} observations."
         )

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -315,6 +315,8 @@ class Flora:
     """An dictionary giving the index of each PFT name in the trait array attributes."""
     n_pfts: int = field(init=False)
     """The number of plant functional types in the Flora instance."""
+    _n_stems: int = field(init=False)
+    """Private attribute for compatibility with StemTraits API."""
 
     def __post_init__(self, pfts: Sequence[type[PlantFunctionalTypeStrict]]) -> None:
         # Check the PFT data
@@ -337,6 +339,7 @@ class Flora:
         # Populate the pft dictionary using the PFT name as key and the number of PFTs
         object.__setattr__(self, "pft_dict", {p.name: p for p in pfts})
         object.__setattr__(self, "n_pfts", len(pfts))
+        object.__setattr__(self, "_n_stems", len(pfts))
 
         # Populate the trait attributes with arrays
         for pft_field in self.trait_attrs:
@@ -350,7 +353,7 @@ class Flora:
     def __repr__(self) -> str:
         """Simple representation of the Flora instance."""
 
-        return f"Flora with {self.n_pfts} functional types: {', '.join(self.name)}"
+        return f"Flora with {self._n_stems} functional types: {', '.join(self.name)}"
 
     @classmethod
     def _from_file_data(cls, file_data: dict) -> Flora:
@@ -501,3 +504,10 @@ class StemTraits:
     """Scaling factor to derive maximum crown radius from crown area."""
     z_max_prop: NDArray[np.float32]
     """Proportion of stem height at which maximum crown radius is found."""
+
+    # Post init attributes
+    _n_stems: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Post init validation and attribute setting."""
+        self._n_stems = len(self.a_hd)

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -9,12 +9,16 @@
   data files. This intentionally enforces a complete description of the traits in the
   input data. The ``PlantFunctionalType`` is provided as a more convenient API for
   programmatic use.
-* The Flora class, which is a dataclass representing a collection of plant functional
-  types for use in describing a plant community in a simulation. It provides the same
-  trait attributes as the plant functional type classes, but the values are arrays of
-  trait values across the provided PFTS. The Flora class also defines factory methods to
-  create instances from plant functional type data stored in JSON, TOML or CSV formats.
-
+* The Flora dataclass, which represents a collection of plant functional types for use
+  in describing a plant community in a simulation. It provides the same trait attributes
+  as the plant functional type classes, but the values are arrays of trait values across
+  the provided PFTS. The Flora class also defines factory methods to create instances
+  from plant functional type data stored in JSON, TOML or CSV formats.
+* The StemTraits dataclass, which represents a collection of stems used in a simulation.
+  It again provides the same trait attributes as the plant functional type classes, but
+  as arrays. This differs from the Flora class in allowing multiple stems of the same
+  plant functional type and is primarily used to broadcast PFT traits into arrays for
+  use in calculating demography across the stems in plant cohorts.
 """  # noqa: D415
 
 from __future__ import annotations
@@ -137,9 +141,9 @@ class PlantFunctionalTypeStrict:
     resp_f: float
     r"""Foliage maintenance respiration fraction (:math:`r_f`,  -)"""
     m: float
-    r"""Canopy shape parameter (:math:`m`, -)"""
+    r"""Crown shape parameter (:math:`m`, -)"""
     n: float
-    r"""Canopy shape parameter (:math:`n`, -)"""
+    r"""Crown shape parameter (:math:`n`, -)"""
     f_g: float
     r"""Crown gap fraction (:math:`f_g`, -)"""
 
@@ -200,6 +204,7 @@ class PlantFunctionalType(PlantFunctionalTypeStrict):
         f_g, 0.05, -
     """
 
+    name: str
     a_hd: float = 116.0
     ca_ratio: float = 390.43
     h_max: float = 25.33
@@ -293,9 +298,9 @@ class Flora:
     resp_f: NDArray[np.float32] = field(init=False)
     r"""Foliage maintenance respiration fraction (:math:`r_f`,  -)"""
     m: NDArray[np.float32] = field(init=False)
-    r"""Canopy shape parameter (:math:`m`, -)"""
+    r"""Crown shape parameter (:math:`m`, -)"""
     n: NDArray[np.float32] = field(init=False)
-    r"""Canopy shape parameter (:math:`n`, -)"""
+    r"""Crown shape parameter (:math:`n`, -)"""
     f_g: NDArray[np.float32] = field(init=False)
     r"""Crown gap fraction (:math:`f_g`, -)"""
     q_m: NDArray[np.float32] = field(init=False)
@@ -487,9 +492,9 @@ class StemTraits:
     resp_f: NDArray[np.float32]
     r"""Foliage maintenance respiration fraction (:math:`r_f`,  -)"""
     m: NDArray[np.float32]
-    r"""Canopy shape parameter (:math:`m`, -)"""
+    r"""Crown shape parameter (:math:`m`, -)"""
     n: NDArray[np.float32]
-    r"""Canopy shape parameter (:math:`n`, -)"""
+    r"""Crown shape parameter (:math:`n`, -)"""
     f_g: NDArray[np.float32]
     r"""Crown gap fraction (:math:`f_g`, -)"""
     q_m: NDArray[np.float32]

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -259,6 +259,7 @@ class Flora:
     ]
 
     # Populated post init
+    # - trait arrays
     name: NDArray[np.str_] = field(init=False)
     r"""The name of the plant functional type."""
     a_hd: NDArray[np.float32] = field(init=False)
@@ -301,10 +302,14 @@ class Flora:
     """Scaling factor to derive maximum crown radius from crown area."""
     z_max_prop: NDArray[np.float32] = field(init=False)
     """Proportion of stem height at which maximum crown radius is found."""
+
+    # - other instance attributes
     pft_dict: dict[str, type[PlantFunctionalTypeStrict]] = field(init=False)
     """A dictionary of the original plant functional type instances, keyed by name."""
     pft_indices: dict[str, int] = field(init=False)
     """An dictionary giving the index of each PFT name in the trait array attributes."""
+    n_pfts: int = field(init=False)
+    """The number of plant functional types in the Flora instance."""
 
     def __post_init__(self, pfts: Sequence[type[PlantFunctionalTypeStrict]]) -> None:
         # Check the PFT data
@@ -324,8 +329,9 @@ class Flora:
                 f"Duplicated plant functional type names: {','.join(duplicates)}"
             )
 
-        # Populate the pft dictionary using the PFT name as key
+        # Populate the pft dictionary using the PFT name as key and the number of PFTs
         object.__setattr__(self, "pft_dict", {p.name: p for p in pfts})
+        object.__setattr__(self, "n_pfts", len(pfts))
 
         # Populate the trait attributes with arrays
         for pft_field in self.trait_attrs:
@@ -335,6 +341,11 @@ class Flora:
 
         # Populate the pft trait indices
         object.__setattr__(self, "pft_indices", {v: k for k, v in enumerate(self.name)})
+
+    def __repr__(self) -> str:
+        """Simple representation of the Flora instance."""
+
+        return f"Flora with {self.n_pfts} functional types: {', '.join(self.name)}"
 
     @classmethod
     def _from_file_data(cls, file_data: dict) -> Flora:

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -97,11 +97,11 @@ class PlantFunctionalTypeStrict:
     * The foliage maintenance respiration fraction was not explicitly included in
       :cite:t:`Li:2014bc` - there was assumed to be a 10% penalty on GPP before
       calculating the other component - but has been explicitly included here.
-    * This implementation adds two further canopy shape parameters (``m`` and ``n`` and
+    * This implementation adds two further crown shape parameters (``m`` and ``n`` and
       ``f_g``). The first two are then used to calculate two constant derived attributes
       (``q_m`` and ``z_max_ratio``) that define the vertical distribution of the crown.
       The last parameter (``f_g``) is the crown gap fraction, that defines the vertical
-      distribution of leaves within the crown. This canopy model parameterisation
+      distribution of leaves within the crown. This crown model parameterisation
       follows the implementation developed in the PlantFATE model :cite:`joshi:2022a`.
 
     See also :class:`~pyrealm.demography.flora.PlantFunctionalType` for the default

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -716,8 +716,10 @@ class StemAllometry:
     crown_z_max: NDArray[np.float32] = field(init=False)
     """Height of maximum crown radius (metres)"""
     # Information attributes
-    _n_z_obs: int = field(init=False)
-    """The number of calculated height values per stem."""
+    _n_pred: int = field(init=False)
+    """The number of predictions per stem."""
+    _n_stems: int = field(init=False)
+    """The number of stems."""
 
     def __post_init__(
         self, stem_traits: Flora | StemTraits, at_dbh: NDArray[np.float32]
@@ -776,19 +778,20 @@ class StemAllometry:
             stem_height=self.stem_height,
         )
 
+        # Set the number of observations per stem (one if dbh is 1D, otherwise size of
+        # the first axis)
         if self.dbh.ndim == 1:
-            self._n_z_obs = 1
+            self._n_pred = 1
         else:
-            self._n_z_obs = self.dbh.shape[0]
+            self._n_pred = self.dbh.shape[0]
+
+        self._n_stems = stem_traits._n_stems
 
     def __repr__(self) -> str:
-        if self._n_z_obs == 1:
-            return f"StemAllometry: Single prediction for {len(self.dbh)} stems"
-        else:
-            return (
-                f"StemAllometry: Prediction for {len(self.dbh)} stems "
-                f"at {self._n_z_obs} DBH values."
-            )
+        return (
+            f"StemAllometry: Prediction for {self._n_stems} stems at se"
+            f"at {self._n_pred} DBH values."
+        )
 
 
 @dataclass()
@@ -920,4 +923,19 @@ class StemAllocation:
                 dbh=stem_allometry.dbh,
                 stem_height=stem_allometry.stem_height,
             )
+        )
+
+        # Set the number of observations per stem (one if dbh is 1D, otherwise size of
+        # the first axis)
+        if self.potential_gpp.ndim == 1:
+            self._n_pred = 1
+        else:
+            self._n_pred = self.potential_gpp.shape[0]
+
+        self._n_stems = stem_traits._n_stems
+
+    def __repr__(self) -> str:
+        return (
+            f"StemAllocation: Prediction for {self._n_stems} stems"
+            f"at {self._n_pred} observations."
         )

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -716,6 +716,9 @@ class StemAllometry:
     """Crown radius scaling factor (-)"""
     crown_z_max: NDArray[np.float32] = field(init=False)
     """Height of maximum crown radius (metres)"""
+    # Information attributes
+    _n_z_obs: int = field(init=False)
+    """The number of calculated height values per stem."""
 
     def __post_init__(
         self, stem_traits: Flora | StemTraits, at_dbh: NDArray[np.float32]
@@ -773,6 +776,20 @@ class StemAllometry:
             z_max_prop=stem_traits.z_max_prop,
             stem_height=self.stem_height,
         )
+
+        if self.dbh.ndim == 1:
+            self._n_z_obs = 1
+        else:
+            self._n_z_obs = self.dbh.shape[0]
+
+    def __repr__(self) -> str:
+        if self._n_z_obs == 1:
+            return f"StemAllometry: Single prediction for {len(self.dbh)} stems"
+        else:
+            return (
+                f"StemAllometry: Prediction for {len(self.dbh)} stems "
+                f"at {self._n_z_obs} DBH values."
+            )
 
 
 @dataclass()

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -715,6 +715,7 @@ class StemAllometry:
     """Crown radius scaling factor (-)"""
     crown_z_max: NDArray[np.float32] = field(init=False)
     """Height of maximum crown radius (metres)"""
+
     # Information attributes
     _n_pred: int = field(init=False)
     """The number of predictions per stem."""
@@ -789,7 +790,7 @@ class StemAllometry:
 
     def __repr__(self) -> str:
         return (
-            f"StemAllometry: Prediction for {self._n_stems} stems at se"
+            f"StemAllometry: Prediction for {self._n_stems} stems "
             f"at {self._n_pred} DBH values."
         )
 
@@ -859,6 +860,12 @@ class StemAllocation:
     """Predicted increase in stem mass from growth allocation (g C)"""
     delta_foliage_mass: NDArray[np.float32] = field(init=False)
     """Predicted increase in foliar mass from growth allocation (g C)"""
+
+    # Information attributes
+    _n_pred: int = field(init=False)
+    """The number of predictions per stem."""
+    _n_stems: int = field(init=False)
+    """The number of stems."""
 
     def __post_init__(
         self,
@@ -936,6 +943,6 @@ class StemAllocation:
 
     def __repr__(self) -> str:
         return (
-            f"StemAllocation: Prediction for {self._n_stems} stems"
+            f"StemAllocation: Prediction for {self._n_stems} stems "
             f"at {self._n_pred} observations."
         )


### PR DESCRIPTION
# Description

This PR is mostly about creating some draft intro docs for users for the demography classes and methods. I have also added some `__repr__` methods to classes and a few information attributes to classes.

Since this is a doc heavy PR, I've set the branch to build on RTD. The new docs are the ones under this TOC heading.

https://pyrealm.readthedocs.io/en/312-add-user-docs-demonstrating-demography-traits-and-crown-properties/users/demography/module_overview.html

Fixes #312 (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
