### PR TITLE
simplify function sigs in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 import sphinxcontrib.bibtex.plugin
+import tuple
 from sphinxcontrib.bibtex.style.referencing import BracketStyle
 from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferenceStyle
 
@@ -177,6 +178,15 @@ add_module_names = False
 # - Group members by type not alphabetically
 autodoc_member_order = "groupwise"
 
+# Control how type hints are shown in the generated documentation
+autodoc_typehints_format = "short"  # Use short format for type hints
+
+# Use unqualified names for types (i.e., without the module prefix)
+python_use_unqualified_type_names = True
+
+napoleon_use_param = False  # Do not show type hints in function signatures
+napoleon_use_rtype = False  # Do not show return types in function signatures
+
 bibtex_bibfiles = ["refs.bib"]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -216,6 +226,23 @@ html_theme_options = {
 html_static_path = ["_static"]
 
 
+# Custom logic to simplify specific types in type annotations
+def simplify_type_hints(signature: str, return_annotation: str) -> tuple[str, str]:
+    """Simplifies function signatures for documentation."""
+    # Replace verbose numpy type hints with simpler versions
+    if signature:
+        signature = signature.replace("~numpy.ndarray", "ndarray")
+        signature = signature.replace("~typing.Any", "Any")
+        signature = signature.replace("~numpy.dtype[~numpy.float32]", "float32")
+    if return_annotation:
+        return_annotation = return_annotation.replace("~numpy.ndarray", "ndarray")
+        return_annotation = return_annotation.replace("~typing.Any", "Any")
+        return_annotation = return_annotation.replace(
+            "~numpy.dtype[~numpy.float32]", "float32"
+        )
+    return signature, return_annotation
+
+
 def setup(app):  # type: ignore
     """Use setup to remove .ipynb from sources.
 
@@ -224,3 +251,5 @@ def setup(app):  # type: ignore
     """
     # Ignore .ipynb files
     app.registry.source_suffix.pop(".ipynb", None)
+    # Connect the event to modify the type hints
+    app.connect("autodoc-process-signature", simplify_type_hints)


### PR DESCRIPTION
# Description

Closes #262 
Fixes #262

This PR looks to simplify the expression of function and class type signatures in the documentation. At present, signatures can render in a verbose manner with excess information that makes parsing the information in the documentation difficult.

Simple `nadarry` type hints, are displayed correctly e.g.

class Calendar(dates: [ndarray])

However, type hints that relate to data that is calculated from a internal method can be excessively complex e.g.

class CoreConst(k_R: float = 8.3145, k_co: float = 209476.0, k_c_molmass: float = 12.0107, k_Po: float = 101325.0, k_To: float = 298.15, k_L: float = 0.0065, k_G: float = 9.80665, k_Ma: float = 0.028963, k_Mv: float = 0.01802, k_CtoK: float = 273.15, k_e: float = 0.0167, k_eps: float = 23.44, magnus_coef: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, mwr: float = 0.622, magnus_option: str | None = None, water_density_method: str = 'fisher', fisher_dial_lambda: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, fisher_dial_Po: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, fisher_dial_Vinf: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, chen_po: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, chen_ko: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, chen_ca: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, chen_cb: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, simple_viscosity: bool = False, huber_tk_ast: float = 647.096, huber_rho_ast: float = 322.0, huber_mu_ast: float = 1e-06, huber_H_i: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>, huber_H_ij: ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>)

This PR aims to simplify expressions of the form:
var:  ~numpy.ndarray[~typing.Any, ~numpy.dtype[~numpy.float32]] = <factory>

To:
var: ndarray[Any, float32] = <factory>

Through use of aliases.

Similarly, type hints relating to variables in dataclasses defined by a `post init` process, are displayed in the following format:

class DailySolarFluxes(lat: dataclasses.InitVar[numpy.ndarray[typing.Any, numpy.dtype[+_ScalarType_co]]], elv: dataclasses.InitVar[numpy.ndarray[typing.Any, numpy.dtype[+_ScalarType_co]]], dates: ~pyrealm.core.calendar.Calendar, sf: dataclasses.InitVar[numpy.ndarray[typing.Any, numpy.dtype[+_ScalarType_co]]], tc: dataclasses.InitVar[numpy.ndarray[typing.Any, numpy.dtype[+_ScalarType_co]]], core_const: ~pyrealm.constants.core_const.CoreConst = <factory>)

 This PR aims to simplify the type hints associated with the arguments in the function/class signature to a simple expression e.g. `arg: ndarray`


## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
