### PR TITLE
Converting canopy

### DIFF
--- a/pyrealm/demography_two/canopy.py
+++ b/pyrealm/demography_two/canopy.py
@@ -1,0 +1,479 @@
+"""Functionality for canopy modelling."""
+
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
+from typing import ClassVar
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.optimize import root_scalar  # type: ignore [import-untyped]
+
+from pyrealm.core.experimental import warn_experimental
+from pyrealm.demography_two.cohorts import Cohorts
+from pyrealm.demography_two.core import ToDataFrameMixin
+from pyrealm.demography_two.crown import (
+    CrownProfile,
+    calculate_relative_crown_radius_at_z,
+    calculate_stem_projected_crown_area_at_z,
+)
+from pyrealm.demography_two.tmodel import StemAllometry
+
+
+def solve_canopy_area_filling_height(
+    z: float,
+    stem_height: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
+    m: NDArray[np.floating],
+    n: NDArray[np.floating],
+    q_m: NDArray[np.floating],
+    z_max: NDArray[np.floating],
+    n_individuals: NDArray[np.floating],
+    target_area: float = 0,
+) -> NDArray[np.floating]:
+    """Solver function for finding the height where a canopy occupies a given area.
+
+    This function takes the number of individuals in each cohort along with the stem
+    height and crown area and a given vertical height (:math:`z`). It then uses the
+    crown shape parameters associated with each cohort to calculate the community wide
+    projected crown area above that height (:math:`A_p(z)`). This is simply the sum of
+    the products of the individual stem crown projected area at :math:`z` and the number
+    of individuals in each cohort.
+
+    The return value is the difference between the calculated :math:`A_p(z)` and a
+    user-specified target area, This allows the function to be used with a root solver
+    to find :math:`z` values that result in a given :math:`A_p(z)`. The default target
+    area is zero, so the default return value will be the actual total :math:`A_p(z)`
+    for the community.
+
+    A typical use case for the target area would be to specify the area at which a given
+    canopy layer closes under the perfect plasticity approximation in order to find the
+    closure height.
+
+    Args:
+        z: Vertical height on the z axis.
+        n_individuals: Number of individuals in each cohort
+        crown_area: Crown area of each cohort
+        stem_height: Stem height of each cohort
+        m: Crown shape parameter ``m``` for each cohort
+        n: Crown shape parameter ``n``` for each cohort
+        q_m: Crown shape parameter ``q_m``` for each cohort
+        z_max: Crown shape parameter ``z_m``` for each cohort
+        target_area: A target projected crown area.
+    """
+    # Convert z to array for validation and typing
+    z_arr = np.array(z)
+
+    q_z = calculate_relative_crown_radius_at_z(
+        z=z_arr, stem_height=stem_height, m=m, n=n
+    )
+    # Calculate A(p) for the stems in each cohort
+    A_p = calculate_stem_projected_crown_area_at_z(
+        z=z_arr,
+        q_z=q_z,
+        stem_height=stem_height,
+        crown_area=crown_area,
+        q_m=q_m,
+        z_max=z_max,
+    )
+
+    return (A_p * n_individuals).sum() - target_area
+
+
+def fit_perfect_plasticity_approximation(
+    cohorts: Cohorts,
+    allometry: StemAllometry,
+    area: float,
+    canopy_gap_fraction: float,
+    max_stem_height: float,
+    solver_tolerance: float,
+) -> NDArray[np.floating]:
+    r"""Find canopy layer heights under the PPA model.
+
+    Finds the closure heights of the canopy layers under the perfect plasticity
+    approximation by fidnding the set of heights that lead to complete closure of canopy
+    layers through the canopy. The function solves the following equation for integers
+    :math:`l \in (1,2,..., m)`:
+
+    .. math::
+
+        \sum_{s=1}^{N_s}{ A_p(z^*_l)} = l A(1 - f_G)
+
+    The right hand side sets out the total area needed to close a given layer :math:`l`
+    and all layers above it:  :math:`l` times the total community area  :math:`A` less
+    any canopy gap fraction (:math:`f_G`). The left hand side then calculates the
+    projected crown area for each stem :math:`s` :math:`A_p(z^*_l)_{[s]}` and sums those
+    areas across all stems in the community  :math:`N_s`. The specific height
+    :math:`z^*_l` is then the height at which the two terms are equal and hence solves
+    the equation for layer :math:`l`.
+
+    Args:
+        cohorts: A set of cohorts.
+        allometry: The stem allometry for those cohorts.
+        area: The area available for canopy to fill.
+        canopy_gap_fraction: The canopy gap fraction
+        max_stem_height: The maximum stem height in the canopy, used as an upper bound
+            on finding the closure height of the topmost layer.
+        solver_tolerance: The absolute tolerance used with the root solver to find the
+            layer heights.
+    """
+
+    # Calculate the number of layers to contain the total community crown area
+    total_community_crown_area = (
+        allometry.crown_area * cohorts.cohorts["n_individuals"]
+    ).sum()
+    crown_area_per_layer = area * (1 - canopy_gap_fraction)
+    n_layers = int(np.ceil(total_community_crown_area / crown_area_per_layer))
+
+    # Initialise the layer heights array and then loop over the layers indices,
+    # except for the final layer, which will be the partial remaining vegetation below
+    # the last closed layer.
+    layer_heights = np.zeros(n_layers, dtype=np.float64)
+    upper_bound = max_stem_height
+
+    for layer in np.arange(n_layers - 1):
+        # Set the target area for this layer
+        target_area = (layer + 1) * crown_area_per_layer
+
+        # TODO - the solution is typically closer to the upper bound of the bracket,
+        # there might be a better algorithm to find the root (#293).
+        solution = root_scalar(
+            solve_canopy_area_filling_height,
+            args=(
+                allometry.stem_height,
+                allometry.crown_area,
+                cohorts.cohorts["m"],
+                cohorts.cohorts["n"],
+                cohorts.cohorts["q_m"],
+                allometry.crown_z_max,
+                cohorts.cohorts["n_individuals"],
+                target_area,
+            ),
+            bracket=(0, upper_bound),
+            xtol=solver_tolerance,
+        )
+
+        if not solution.converged:
+            raise RuntimeError(
+                "Estimation of canopy layer closure heights failed to converge."
+            )
+
+        # Store the solution and update the upper bound for the next layer down.
+        layer_heights[layer] = upper_bound = solution.root
+
+    return layer_heights
+
+
+@dataclass
+class CohortCanopyData(ToDataFrameMixin):
+    """Dataclass holding canopy data across cohorts.
+
+    The cohort canopy data consists of a set of attributes represented as two
+    dimensional arrays. Each row is different height at which canopy properties are
+    required and the columns represent the different cohorts or the identical stem
+    properties of individuals within cohorts.
+
+    The data class:
+
+    1. Takes the projected leaf area at the required heights and then partitions this
+       into the actual leaf area within each layer, the leaf area index across the whole
+       cohort and then then light absorption and transmission fractions of each cohort
+       at each level.
+
+    2. Calculates the community-wide transmission and absorption profiles. These are
+       generated as an instance of the class
+       :class:`~pyrealm.demography.canopy.CommunityCanopyData` and stored in the
+       ``community_data`` attribute.
+
+    3. Allocates the community-wide absorption across cohorts. The total fraction of
+       light absorbed across layers is a community-wide property
+       - each cohort contributes to the cumulative light absorption. Once the light
+       absorbed within a layer of the community is known, this can then be partitioned
+       back to cohorts and individual stems to give the fraction of canopy top
+       radiation intercepted by each stem within each layer.
+
+    Args:
+        projected_leaf_area: A two dimensional array providing projected leaf area for a
+            set of cohorts (columns) at a set of required heights (rows), as for example
+            calculated using the :class:`~pyrealm.demography.crown.CrownProfile` class.
+        n_individuals: A one-dimensional array of the number of individuals in each
+            cohort.
+        lai: A one-dimensional array giving the leaf area index trait for the plant
+            functional type of each cohort.
+        par_ext: A one-dimensional array giving the light extinction coefficient for
+            the plant functional type of each cohort.
+        cell_area: A float setting the total canopy area available to the cohorts.
+    """
+
+    _array_attrs: ClassVar[tuple[str, ...]] = (
+        "stem_leaf_area",
+        "fapar",
+    )
+
+    _ndims: ClassVar[int] = 2
+
+    # Init vars
+    projected_leaf_area: InitVar[NDArray[np.floating]]
+    """An array of the stem projected leaf area for each cohort at each of the required
+    heights."""
+    n_individuals: InitVar[NDArray[np.int_]]
+    """The number of individuals for each cohort."""
+    lai: InitVar[NDArray[np.floating]]
+    """The leaf area index of the plant functional type for each cohort."""
+    par_ext: InitVar[NDArray[np.floating]]
+    """The extinction coefficient of the plant functional type for each cohort."""
+    cell_area: InitVar[float]
+    """The area available to the community."""
+
+    # Computed variables
+    stem_leaf_area: NDArray[np.floating] = field(init=False)
+    """The leaf area of the crown model for each cohort by layer."""
+    cohort_absorption: NDArray[np.floating] = field(init=False)
+    """The Beer-Lambert absorption fraction for each cohort."""
+    fapar: NDArray[np.floating] = field(init=False)
+    """The across layer fractions of absorbed radiation for each cohort by layer."""
+
+    # Community wide attributes in their own class
+    community_data: CommunityCanopyData = field(init=False)
+    """The community wide canopy properties."""
+
+    __experimental__ = True
+
+    def __post_init__(
+        self,
+        projected_leaf_area: NDArray[np.floating],
+        n_individuals: NDArray[np.int_],
+        lai: NDArray[np.floating],
+        par_ext: NDArray[np.floating],
+        cell_area: float,
+    ) -> None:
+        """Calculates cohort canopy attributes from the input data."""
+
+        warn_experimental("CohortCanopyData")
+
+        # Partition the projected leaf area into the leaf area in each layer for each
+        # stem and then scale up to the cohort leaf area in each layer.
+        self.stem_leaf_area = np.diff(projected_leaf_area, axis=0, prepend=0)
+
+        # Calculate Beer-Lambert light absorption coefficient for each cohort
+        self.cohort_absorption = 1.0 - np.exp(-par_ext * lai)
+
+        # Calculate the community wide properties across cohorts:
+        # - average light transmission through each layer
+        # - average lai within each layer
+        # - the cumulative light transmission profile
+        self.community_data = CommunityCanopyData(
+            absorption=self.cohort_absorption,
+            leaf_area_index=lai,
+            cohort_leaf_area=self.stem_leaf_area * n_individuals,
+            cell_area=cell_area,
+        )
+
+        # Now calculate the theoretical fAPAR for each cohort in each layer as the outer
+        # product of the within layer absorption for each cohort and the transmission
+        # profile giving the mean light transmission through each layer.
+        self.fapar = np.outer(
+            self.community_data.transmission_profile, self.cohort_absorption
+        )
+
+
+@dataclass
+class CommunityCanopyData(ToDataFrameMixin):
+    """Dataclass holding community-wide canopy data.
+
+    The community canopy data consists of a set of attributes represented as one
+    dimensional arrays, with each entry representing a different vertical height at
+    which canopy properties are required.
+
+    The data class takes the expected light transmission for each cohort within each
+    layer (as the prediction from the Beer-Lambert law for the cohort), along with the
+    total leaf area in each layer within each cohort, and uses this to calculate the
+    average light transmission profile down through the canopy layers. It also
+    calculates the average leaf area index within each layer.
+
+    The cumulative transmission profile shows the fraction of light reaching each of the
+    canopy layers given the average absorption of the layer above, starting with 1 to
+    represent the light reaching the canopy top. The fraction of light reaching the
+    ground below the canopy is stored as the `transmission_to_ground` attribute.
+
+    Args:
+        absorption: The expected light absorption for cohorts within each layer.
+        leaf_area_index: The leaf area index of cohorts within layers.
+        cohort_leaf_area: The total leaf area of each cohort in each layer.
+        cell_area: The area of the cell containing the community.
+    """
+
+    _array_attrs: ClassVar[tuple[str, ...]] = (
+        "average_layer_absorption",
+        "average_layer_fapar",
+        "average_layer_lai",
+        "transmission_profile",
+    )
+
+    _ndims: ClassVar[int] = 1
+
+    # Init vars
+    absorption: InitVar[NDArray[np.floating]]
+    """The Beer Lambert light absorption fraction for each cohort."""
+    leaf_area_index: InitVar[NDArray[np.floating]]
+    """The leaf area index for each cohort."""
+    cohort_leaf_area: InitVar[NDArray[np.floating]]
+    """The total leaf area per cohort for each layer."""
+    cell_area: InitVar[float]
+    """The total area within the community."""
+
+    # Calculated variables
+    average_layer_absorption: NDArray[np.floating] = field(init=False)
+    """The average absorption within layers across the community."""
+    average_layer_fapar: NDArray[np.floating] = field(init=False)
+    """The average fAPAR of the community for each layer."""
+    average_layer_lai: NDArray[np.floating] = field(init=False)
+    """The average leaf area index of the community within layers."""
+    transmission_profile: NDArray[np.floating] = field(init=False)
+    """The light transmission profile through the canopy by layer."""
+    transmission_to_ground: NDArray[np.floating] = field(init=False)
+    """The fraction of light reaching the ground below the canopy."""
+
+    __experimental__ = True
+
+    def __post_init__(
+        self,
+        absorption: NDArray[np.floating],
+        leaf_area_index: NDArray[np.floating],
+        cohort_leaf_area: NDArray[np.floating],
+        cell_area: float,
+    ) -> None:
+        """Calculates community-wide canopy attributes from the input data."""
+
+        warn_experimental("CommunityCanopyData")
+
+        # Get the average absorption within the layer: per cohort values weighted by
+        # cohort leaf area and scaled back to cell area.
+        self.average_layer_absorption = (absorption * cohort_leaf_area).sum(
+            axis=1
+        ) / cell_area
+
+        # Calculate the average LAI within the layer
+        self.average_layer_lai = (leaf_area_index * cohort_leaf_area).sum(
+            axis=1
+        ) / cell_area
+
+        # Calculate the cumulative light transmission profile across layers, adding 1 to
+        # give the proportion of light available to the first layer.
+        full_transmission = np.cumprod(
+            np.concat([[1], (1 - self.average_layer_absorption)])
+        )
+        # Record the fapar as the difference between layers and then store the
+        # transmission profile, moving the last value into a separate property to
+        # maintain the layer data frame.
+        self.average_layer_fapar = np.diff(-full_transmission)
+        self.transmission_profile = full_transmission[:-1]
+        self.transmission_to_ground = full_transmission[-1]
+
+
+class Canopy:
+    """Calculate canopy characteristics for a plant community.
+
+    This class generates a canopy structure for a community of trees using the
+    perfect-plasticity approximation (PPA) model :cite:`purves:2008a`. In this approach,
+    each individual is assumed to arrange its canopy crown area plastically to take up
+    space in canopy layers and that new layers form below the canopy top as the
+    available space is occupied.
+
+    Real canopies contain canopy gaps, through process such as crown shyness. This
+    is included in the model through the canopy gap fraction, which sets the proportion
+    of the available space that will remain unfilled by any canopy.
+
+    Args:
+        community: A Community object that will be used to generate the canopy model.
+        layer_heights: A column array of vertical heights at which to calculate canopy
+            variables.
+        fit_ppa: Calculate layer heights as the canopy layer closure heights under the
+            PPA model.
+        canopy_gap_fraction: The proportion of the available space unfilled by canopy
+            (default: 0.05).
+        layer_tolerance: The minimum precision used by the solver to find canopy layer
+            closure heights (default: 0.001 metres)
+    """
+
+    __experimental__ = True
+
+    def __init__(
+        self,
+        cohorts: Cohorts,
+        allometry: StemAllometry,
+        canopy_area: float,
+        layer_heights: NDArray[np.floating] | None = None,
+        fit_ppa: bool = False,
+        canopy_gap_fraction: float = 0,
+        solver_tolerance: float = 0.001,
+    ) -> None:
+        # Warn that this is an experimental feature
+        warn_experimental("Canopy")
+
+        # Store required init vars
+        self.canopy_gap_fraction: float = canopy_gap_fraction
+        """Canopy gap fraction."""
+        self.solver_tolerance: float = solver_tolerance
+        """Numerical tolerance for fitting the PPA model of canopy layer closure."""
+
+        # Define class attributes
+        self.max_stem_height: float
+        """Maximum height of any individual in the community (m)."""
+        self.n_layers: int
+        """Total number of canopy layers."""
+        self.n_cohorts: int
+        """Total number of cohorts in the canopy."""
+        self.heights: NDArray[np.floating]
+        """The vertical heights at which the canopy structure is calculated."""
+
+        self.crown_profile: CrownProfile
+        """The crown profiles of the community stems at the provided layer heights."""
+        self.cohort_data: CohortCanopyData
+        """The per-cohort canopy data."""
+        self.community_data: CommunityCanopyData
+        """The community-wide canopy data."""
+        self.filled_community_area: float
+        """The area filled by crown after accounting for the crown gap fraction."""
+
+        # Check operating mode
+        if fit_ppa ^ (layer_heights is None):
+            raise ValueError("Either set fit_ppa=True or provide layer heights.")
+
+        # Set simple attributes
+        self.max_stem_height = allometry.stem_height.max()
+        self.n_cohorts = cohorts.n_cohorts
+        self.filled_community_area = canopy_area * (1 - self.canopy_gap_fraction)
+
+        # Populate layer heights
+        if layer_heights is not None:
+            self.heights = layer_heights
+        else:
+            self.heights = fit_perfect_plasticity_approximation(
+                cohorts=cohorts,
+                allometry=allometry,
+                area=canopy_area,
+                canopy_gap_fraction=canopy_gap_fraction,
+                max_stem_height=self.max_stem_height,
+                solver_tolerance=solver_tolerance,
+            )
+
+        # Calculate the crown profile at the layer heights
+        self.crown_profile = CrownProfile(
+            cohorts=cohorts,
+            allometry=allometry,
+            z=self.heights,
+        )
+
+        # Calculate the per cohort canopy components (LAI, f_trans, f_abs) from the
+        # projected leaf area for each stem at the layer heights
+        self.cohort_data = CohortCanopyData(
+            projected_leaf_area=self.crown_profile.projected_leaf_area,
+            n_individuals=cohorts.cohorts["n_individuals"].to_numpy(),
+            lai=cohorts.cohorts["lai"].to_numpy(),
+            par_ext=cohorts.cohorts["par_ext"].to_numpy(),
+            cell_area=canopy_area,
+        )
+
+        # Create a shorter reference to the community data
+        self.community_data = self.cohort_data.community_data

--- a/tests/array_inputs/overrides.py
+++ b/tests/array_inputs/overrides.py
@@ -47,6 +47,7 @@ SKIP_METHODS = [
     "Cohorts.drop_cohort_data",
     "CrownProfile",
     "CrownProfile.to_xy",
+    "Canopy",
     # Demography - mostly 1d arrays (dataframes)
     "StemAllocation",
     "StemAllometry",

--- a/tests/unit/demography_two/conftest.py
+++ b/tests/unit/demography_two/conftest.py
@@ -88,3 +88,25 @@ def rtmodel_data():
     rdata_arrays = {k: np.reshape(v, (3, 6)).T for k, v in rdata.items()}
 
     return rdata_arrays
+
+
+@pytest.fixture
+def fixture_cohorts_and_allometry():
+    """A fixture providing a simple community."""
+
+    from pyrealm.demography_two.cohorts import Cohorts
+    from pyrealm.demography_two.flora import Flora
+    from pyrealm.demography_two.tmodel import StemAllometry
+
+    # A simple community containing one sample stem, with an initial crown gap fraction
+    # of zero.
+    flora = Flora(name=["test"], f_g=[0.0])
+    cohorts = Cohorts(
+        pft_name=np.array(["test"] * 4),
+        dbh_value=np.array([0.2, 0.4, 0.6, 0.8]),
+        n_individuals=np.array([1] * 4),
+        flora=flora,
+    )
+    allometry = StemAllometry(cohorts=cohorts)
+
+    return cohorts, allometry

--- a/tests/unit/demography_two/test_canopy.py
+++ b/tests/unit/demography_two/test_canopy.py
@@ -1,0 +1,265 @@
+"""Testing the Canopy object."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+
+@pytest.mark.parametrize(
+    argnames="""
+    cohort_args, 
+    cohort_fapar, 
+    community_lai, 
+    community_transmission,
+    transmission_to_ground
+    """,
+    argvalues=(
+        [
+            pytest.param(
+                {
+                    "projected_leaf_area": np.tile([[2], [4], [6], [8]], 3),
+                    "n_individuals": np.array([2, 2, 2]),
+                    "lai": np.array([2, 2, 2]),
+                    "par_ext": np.array([0.5, 0.5, 0.5]),
+                    "cell_area": 12,
+                },
+                np.outer(
+                    np.cumprod(np.concat([[1], np.repeat(np.exp(-1), 3)])),
+                    1 - np.repeat(np.exp(-1), 3),
+                ),
+                np.repeat(2, 4),
+                np.cumprod(np.concat([[1], np.repeat(np.exp(-1), 3)])),
+                np.exp(-1) ** 4,
+                id="four_layers",
+            ),
+            pytest.param(
+                {
+                    "projected_leaf_area": np.cumsum(
+                        np.array(
+                            [
+                                [6, 2, 0],
+                                [4, 4, 0],
+                                [3, 3, 1],
+                                [0, 2, 3],
+                                [0, 0, 1],
+                            ]
+                        ),
+                        axis=0,
+                    ),
+                    "lai": np.array([2, 1, 2]),
+                    "par_ext": np.array([0.5, 0.5, 0.6]),
+                    "n_individuals": np.array([1, 1, 2]),
+                    "cell_area": 8,
+                },
+                np.array(
+                    [
+                        [0.632121, 0.393469, 0.698806],
+                        [0.270258, 0.168225, 0.298769],
+                        [0.131671, 0.08196, 0.145562],
+                        [0.058028, 0.03612, 0.064149],
+                        [0.021907, 0.013636, 0.024218],
+                    ]
+                ),
+                np.array([1.75, 1.5, 1.625, 1.75, 0.5]),
+                np.array([1.0, 0.427542, 0.208301, 0.091799, 0.034657]),
+                np.array([0.028602]),
+                id="simulation_outputs",
+            ),
+        ]
+    ),
+)
+def test_CohortCanopyData__init__(
+    cohort_args,
+    cohort_fapar,
+    community_lai,
+    community_transmission,
+    transmission_to_ground,
+):
+    """Shared testing of the cohort and community canopy dataclasses.
+
+    Since the creation of the community canopy data is built into the cohort canopy
+    data creation, that dataclass is implicitly tested by checking the CohortCanopyData
+    class.
+
+    The simple four layer test uses three identical cohorts to give some easily defined
+    expected values. The simulation test data is a simple example used in the light
+    capture model documentation notebook. This test includes:
+
+    * varying PFT values in LAI and extinction coefficient
+    * differing numbers of individuals and
+    * includes an incomplete final layer
+    """
+
+    from pyrealm.demography_two.canopy import CohortCanopyData
+
+    # Calculate canopy components
+    instance = CohortCanopyData(**cohort_args)
+
+    # Test cohort expected fapar
+    assert_allclose(instance.fapar, cohort_fapar, atol=1e-6)
+
+    # Test community expected lai and transmission
+    assert_allclose(
+        instance.community_data.transmission_profile, community_transmission, atol=1e-6
+    )
+    assert_allclose(instance.community_data.average_layer_lai, community_lai, atol=1e-6)
+
+    # Test the inherited to_pandas method of the cohort canopy data
+    df = instance.to_dataframe()
+
+    assert df.shape == (
+        np.prod(cohort_args["projected_leaf_area"].shape),
+        len(instance._array_attrs),
+    )
+
+    assert set(instance._array_attrs) == set(df.columns)
+
+    # Test the inherited to_pandas method of the community canopy data
+    df = instance.community_data.to_dataframe()
+
+    assert df.shape == (
+        len(instance.community_data.transmission_profile),
+        len(instance.community_data._array_attrs),
+    )
+
+    assert set(instance.community_data._array_attrs) == set(df.columns)
+
+
+def test_Canopy__init__():
+    """Test initialisation.
+
+    Test that when a new canopy object is instantiated, it contains the expected
+    properties.
+    """
+
+    from pyrealm.demography_two.canopy import Canopy
+    from pyrealm.demography_two.cohorts import Cohorts
+    from pyrealm.demography_two.flora import Flora
+    from pyrealm.demography_two.tmodel import StemAllometry
+
+    flora = Flora(name=["broadleaf", "conifer"], h_max=[30, 20])
+    cohorts = Cohorts(
+        flora=flora,
+        pft_name=np.array(["broadleaf", "conifer"]),
+        n_individuals=np.array([6, 1]),
+        dbh_value=np.array([0.2, 0.5]),
+    )
+    allometry = StemAllometry(cohorts=cohorts)
+
+    canopy_gap_fraction = 0.05
+    cell_area = 20
+    canopy = Canopy(
+        cohorts=cohorts,
+        allometry=allometry,
+        canopy_area=cell_area,
+        canopy_gap_fraction=canopy_gap_fraction,
+        fit_ppa=True,
+    )
+
+    # Simply check that the shape of the stem leaf area matrix is the right shape
+    n_layers_from_crown_area = int(
+        np.floor(
+            (
+                (allometry.crown_area * cohorts.cohorts["n_individuals"]).sum()
+                * (1 + canopy_gap_fraction)
+            )
+            / cell_area
+        )
+    )
+    assert canopy.cohort_data.stem_leaf_area.shape == (
+        n_layers_from_crown_area,
+        canopy.n_cohorts,
+    )
+
+
+def test_solve_canopy_area_filling_height(fixture_cohorts_and_allometry):
+    """Test solve_community_projected_canopy_area.
+
+    The logic of this test is that given the cumulative sum of the crown areas in the
+    fixture from tallest to shortest as the target, providing the z_max of each stem as
+    the height _should_ always return zero, as this is exactly the height at which that
+    cumulative area would close: crown 1 closes at z_max 1, crown 1 + 2 closes at z_max
+    2 and so on.
+    """
+
+    from pyrealm.demography.canopy import solve_canopy_area_filling_height
+
+    cohorts, allometry = fixture_cohorts_and_allometry
+
+    for (
+        this_height,
+        this_target,
+    ) in zip(
+        np.flip(allometry.crown_z_max.flatten()),
+        np.cumsum(np.flip(allometry.crown_area)),
+    ):
+        solved = solve_canopy_area_filling_height(
+            z=this_height,
+            stem_height=allometry.stem_height,
+            crown_area=allometry.crown_area,
+            n_individuals=cohorts.cohorts["n_individuals"],
+            m=cohorts.cohorts["m"],
+            n=cohorts.cohorts["n"],
+            q_m=cohorts.cohorts["q_m"],
+            z_max=allometry.crown_z_max,
+            target_area=this_target,
+        )
+
+    assert solved == pytest.approx(0)
+
+
+def test_fit_perfect_plasticity_approximation():
+    """Test the PPA solver.
+
+    The logic of this test is to construct a community of 3 singleton cohorts with DBH
+    at 10, 20, 30 metres, but where the PFT traits are back-calculated so that each stem
+    has the same 60 metre crown area. The PPA solver should then find that the layer
+    closure occurs at the stems heights where the crown is widest (crown_z_max).
+
+    This does rely on the canopy shape being flat topped enough that the crowns do not
+    overlap vertically.
+    """
+
+    from pyrealm.demography_two.canopy import fit_perfect_plasticity_approximation
+    from pyrealm.demography_two.cohorts import Cohorts
+    from pyrealm.demography_two.flora import Flora
+    from pyrealm.demography_two.tmodel import StemAllometry, calculate_dbh_from_height
+
+    # Calculate DBH from target stem heights
+    stem_height = np.array([30, 20, 10])
+    h_max = np.array([35, 35, 35])
+    a_hd = np.array([116, 116, 116])
+    dbh = calculate_dbh_from_height(h_max=h_max, a_hd=a_hd, stem_height=stem_height)
+
+    # Set the desired cell area and then back-calculate the ca_ratio trait to give each
+    # stem that crown area
+    area = 60
+    ca_ratio = (4 * a_hd * area) / (np.pi * stem_height * dbh)
+
+    # Set up the inputs.
+    flora = Flora(
+        name=["a", "b", "c"],
+        h_max=list(h_max),
+        a_hd=list(a_hd),
+        ca_ratio=list(ca_ratio),
+    )
+    cohorts = Cohorts(
+        flora=flora,
+        pft_name=np.array(["a", "b", "c"]),
+        dbh_value=dbh,
+        n_individuals=np.ones(3).astype(int),
+    )
+    allometry = StemAllometry(cohorts)
+
+    # Fit the model
+    tolerance = 1e-8
+    heights = fit_perfect_plasticity_approximation(
+        cohorts=cohorts,
+        allometry=allometry,
+        area=area,
+        canopy_gap_fraction=0,
+        max_stem_height=30,
+        solver_tolerance=tolerance,
+    )
+
+    assert np.allclose(heights, allometry.crown_z_max, atol=tolerance)

--- a/tests/unit/demography_two/test_canopy.py
+++ b/tests/unit/demography_two/test_canopy.py
@@ -158,7 +158,7 @@ def test_Canopy__init__():
 
     # Simply check that the shape of the stem leaf area matrix is the right shape
     n_layers_from_crown_area = int(
-        np.floor(
+        np.ceil(
             (
                 (allometry.crown_area * cohorts.cohorts["n_individuals"]).sum()
                 * (1 + canopy_gap_fraction)
@@ -262,4 +262,7 @@ def test_fit_perfect_plasticity_approximation():
         solver_tolerance=tolerance,
     )
 
-    assert np.allclose(heights, allometry.crown_z_max, atol=tolerance)
+    # Add the final zero to represent remaining gap to ground.
+    assert np.allclose(
+        heights, np.concatenate([allometry.crown_z_max, [0]]), atol=tolerance
+    )

--- a/tests/unit/demography_two/test_crown.py
+++ b/tests/unit/demography_two/test_crown.py
@@ -211,28 +211,6 @@ def fixture_z_qz_test_cases(which):
             )
 
 
-@pytest.fixture
-def fixture_cohorts_and_allometry():
-    """A fixture providing a simple community."""
-
-    from pyrealm.demography_two.cohorts import Cohorts
-    from pyrealm.demography_two.flora import Flora
-    from pyrealm.demography_two.tmodel import StemAllometry
-
-    # A simple community containing one sample stem, with an initial crown gap fraction
-    # of zero.
-    flora = Flora(name=["test"], f_g=[0.0])
-    cohorts = Cohorts(
-        pft_name=np.array(["test"] * 4),
-        dbh_value=np.array([0.2, 0.4, 0.6, 0.8]),
-        n_individuals=np.array([1] * 4),
-        flora=flora,
-    )
-    allometry = StemAllometry(cohorts=cohorts)
-
-    return cohorts, allometry
-
-
 @pytest.mark.parametrize(
     argnames="which",
     argvalues=[


### PR DESCRIPTION
# Description

This PR updates the `demography_two.canopy` module to use the downstream API changes in the demography restructure. It adds a new test that checks the perfect plasticity approximation solver works as expected - this function wasn't tested directly in the previous `demography` module.

Fixes #662

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
