### PR TITLE
Version 300rc2 changes

### DIFF
--- a/docs/source/users/demography/allometry.md
+++ b/docs/source/users/demography/allometry.md
@@ -156,6 +156,6 @@ DBH.
 
 ```{code-cell} ipython3
 allometry_profiles.to_dataframe().head(6)[
-    ["cohort_ids", "dbh", "stem_height", "crown_area", "crown_fraction"]
+    ["cohort_id", "dbh", "stem_height", "crown_area", "crown_fraction"]
 ]
 ```

--- a/docs/source/users/demography/allometry.md
+++ b/docs/source/users/demography/allometry.md
@@ -9,16 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  name: python
-  version: 3.14.3
-  mimetype: text/x-python
-  codemirror_mode:
-    name: ipython
-    version: 3
-  pygments_lexer: ipython3
-  nbconvert_exporter: python
-  file_extension: .py
 ---
 
 # Allometry in the T Model
@@ -55,7 +45,7 @@ To generate allometric predictions under the T Model, we need to define a set of
 
 ```{code-cell} ipython3
 # Create a flora with 3 PFTs with different maximum heights
-flora = Flora(name=["short", "medium", "tall"], h_max=[10, 20, 30])
+flora = Flora(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30))
 
 # Create an id generator.
 cid_generator = cohort_id_generator(mode="str")
@@ -142,7 +132,7 @@ plot_details = [
 ]
 
 for ax, (var, ylab) in zip(axes.flatten(), plot_details):
-    ax.plot(dbh_profile, getattr(allometry_profiles, var), label=flora.name)
+    ax.plot(dbh_profile, getattr(allometry_profiles, var), label=flora.pft_name)
     ax.set_xlabel("Diameter at breast height (m)")
     ax.set_ylabel(ylab)
 

--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -8,16 +8,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  name: python
-  version: 3.12.3
-  mimetype: text/x-python
-  codemirror_mode:
-    name: ipython
-    version: 3
-  pygments_lexer: ipython3
-  nbconvert_exporter: python
-  file_extension: .py
 ---
 
 # The canopy model
@@ -118,12 +108,12 @@ individual stems, grouped into 3 cohorts with different stem sizes and crown sha
 ```{code-cell} ipython3
 # Create a flora
 flora = Flora(
-    name=["short", "tall"],
-    h_max=[15, 30],
-    m=[2, 2],
-    n=[4, 3],
-    f_g=[0, 0],
-    ca_ratio=[380, 500],
+    pft_name=("short", "tall"),
+    h_max=(15, 30),
+    m=(2, 2),
+    n=(4, 3),
+    f_g=(0, 0),
+    ca_ratio=(380, 500),
 )
 
 # Create an id generator.
@@ -388,12 +378,12 @@ and canopy gap fractions.
 ```{code-cell} ipython3
 # Define a flora with PFTs that have crown gap fractions
 gappy_flora = Flora(
-    name=["short", "tall"],
-    h_max=[15, 30],
-    m=[2, 2],
-    n=[4, 3],
-    f_g=[0.1, 0.1],
-    ca_ratio=[380, 500],
+    pft_name=("short", "tall"),
+    h_max=(15, 30),
+    m=(2, 2),
+    n=(4, 3),
+    f_g=(0.1, 0.1),
+    ca_ratio=(380, 500),
 )
 
 # Define a community with three cohorts of stems with gappy canopies
@@ -499,8 +489,4 @@ ax2.set_xlabel("Projected community area (m2)")
 ax2.legend(framealpha=1.0)
 
 plt.tight_layout()
-```
-
-```{code-cell} ipython3
-
 ```

--- a/docs/source/users/demography/carbon_allocation.md
+++ b/docs/source/users/demography/carbon_allocation.md
@@ -9,16 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  name: python
-  version: 3.14.3
-  mimetype: text/x-python
-  codemirror_mode:
-    name: ipython
-    version: 3
-  pygments_lexer: ipython3
-  nbconvert_exporter: python
-  file_extension: .py
 ---
 
 # The T Model module
@@ -62,7 +52,7 @@ and their stem allometry:
 
 ```{code-cell} ipython3
 # Create a flora with 3 PFTs with different maximum heights
-flora = Flora(name=["short", "medium", "tall"], h_max=[10, 20, 30])
+flora = Flora(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30))
 
 # Create an id generator.
 cid_generator = cohort_id_generator(mode="str")
@@ -195,7 +185,9 @@ plot_details = [
 axes = axes.flatten()
 
 for ax, (var, ylab) in zip(axes, plot_details):
-    ax.plot(whole_crown_gpp_profile, getattr(allocation_profile, var), label=flora.name)
+    ax.plot(
+        whole_crown_gpp_profile, getattr(allocation_profile, var), label=flora.pft_name
+    )
     ax.set_xlabel("GPP (m)")
     ax.set_ylabel(ylab)
 

--- a/docs/source/users/demography/carbon_allocation.md
+++ b/docs/source/users/demography/carbon_allocation.md
@@ -208,5 +208,5 @@ Again, with GPP profiles, the
 predictions into columns identified by pairings of cohort ID and DBH.
 
 ```{code-cell} ipython3
-allocation_profile.to_dataframe().head(6)[["cohort_ids", "whole_crown_gpp", "npp"]]
+allocation_profile.to_dataframe().head(6)[["cohort_id", "whole_crown_gpp", "npp"]]
 ```

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -9,16 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  name: python
-  version: 3.12.3
-  mimetype: text/x-python
-  codemirror_mode:
-    name: ipython
-    version: 3
-  pygments_lexer: ipython3
-  nbconvert_exporter: python
-  file_extension: .py
 ---
 
 # The tree crown model
@@ -238,11 +228,11 @@ a `Flora` object using the PFTs.
 ```{code-cell} ipython3
 # Generate a Flora instance using those PFTs
 flora = Flora(
-    name=["narrow", "medium", "wide"],
-    h_max=[20, 20, 20],
-    m=[1.5, 1.5, 4],
-    n=[1.5, 4, 1.5],
-    ca_ratio=[20, 500, 2000],
+    pft_name=("narrow", "medium", "wide"),
+    h_max=(20, 20, 20),
+    m=(1.5, 1.5, 4),
+    n=(1.5, 4, 1.5),
+    ca_ratio=(20, 500, 2000),
 )
 flora
 ```
@@ -251,7 +241,7 @@ The key canopy variables from the flora are:
 
 ```{code-cell} ipython3
 flora.to_dataframe()[
-    ["name", "h_max", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]
+    ["pft_name", "h_max", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]
 ]
 ```
 
@@ -414,12 +404,12 @@ but different shapes and gap fractions.
 
 ```{code-cell} ipython3
 flora = Flora(
-    name=["no_gaps", "few_gaps", "many_gaps"],
-    h_max=[20, 20, 20],
-    m=[1.5, 1.5, 4.0],
-    n=[1.5, 4.0, 1.5],
-    f_g=[0.0, 0.1, 0.3],
-    ca_ratio=[380, 400, 420],
+    pft_name=("no_gaps", "few_gaps", "many_gaps"),
+    h_max=(20, 20, 20),
+    m=(1.5, 1.5, 4.0),
+    n=(1.5, 4.0, 1.5),
+    f_g=(0.0, 0.1, 0.3),
+    ca_ratio=(380, 400, 420),
 )
 
 # Create an id generator.
@@ -496,7 +486,7 @@ for f_g in np.linspace(0, 1, num=11):
 
     # Create a flora with a single PFT with current f_g and then generate a
     # stem allometry and crown profile
-    flora = Flora(name=["pft"], h_max=[20], m=[2], n=[2], f_g=[f_g])
+    flora = Flora(pft_name=("pft",), h_max=(20,), m=(2,), n=(2,), f_g=(f_g,))
 
     # Create the cohorts
     cohorts = create_cohorts(
@@ -577,8 +567,8 @@ for cr_xy, (ch, cpr), (lh, lpr) in zip(
     crown_radius_as_xy, projected_crown_radius_xy, projected_leaf_radius_xy
 ):
     ax.add_patch(Polygon(cr_xy, color="lightgrey", fill=True))
-    ax.plot(cpr, ch, color="0.4", linewidth=2)
-    ax.plot(lpr, lh, color="red", linewidth=1)
+    ax.plot(ch, cpr, color="0.4", linewidth=2)
+    ax.plot(lh, lpr, color="red", linewidth=1)
 
 ax.set_aspect(0.5)
 _ = plt.legend(
@@ -592,4 +582,8 @@ _ = plt.legend(
     bbox_to_anchor=(0.5, 1.15),
     frameon=False,
 )
+```
+
+```{code-cell} ipython3
+
 ```

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -9,16 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  name: python
-  version: 3.12.3
-  mimetype: text/x-python
-  codemirror_mode:
-    name: ipython
-    version: 3
-  pygments_lexer: ipython3
-  nbconvert_exporter: python
-  file_extension: .py
 ---
 
 # Plant functional types and cohorts
@@ -125,7 +115,7 @@ each trait but if you omit some traits then they will be automatically populated
 from default values.
 
 ```{code-cell} ipython3
-flora = Flora(name=["short", "medium", "tall"], h_max=(10, 20, 30))
+flora = Flora(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30))
 flora
 ```
 

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -120,12 +120,12 @@ the PlantFATE model {cite}`joshi:2022a`.
 
 The {class}`~pyrealm.demography.flora.Flora` class is used to create a set of PFTs
 that will be used in a demographic simulation. It can be created directly by providing
-a list of values for each trait: you must provide the same length list of values for
+a tuple of values for each trait: you must provide the same length list of values for
 each trait but if you omit some traits then they will be automatically populated
 from default values.
 
 ```{code-cell} ipython3
-flora = Flora(name=["short", "medium", "tall"], h_max=[10, 20, 30])
+flora = Flora(name=["short", "medium", "tall"], h_max=(10, 20, 30))
 flora
 ```
 

--- a/docs/source/users/demography/light_capture.md
+++ b/docs/source/users/demography/light_capture.md
@@ -492,13 +492,13 @@ canopy model](./canopy.md) calculations.
 ```{code-cell} ipython3
 # Define a flora with PFTs that have crown gap fractions
 gappy_flora = Flora(
-    name=["short", "tall"],
-    h_max=[15, 30],
-    m=[1.5, 1.5],
-    n=[3, 1.5],
-    par_ext=[0.5, 0.6],
-    f_g=[0.1, 0.1],
-    ca_ratio=[380, 500],
+    pft_name=("short", "tall"),
+    h_max=(15, 30),
+    m=(1.5, 1.5),
+    n=(3, 1.5),
+    par_ext=(0.5, 0.6),
+    f_g=(0.1, 0.1),
+    ca_ratio=(380, 500),
 )
 
 cid_generator = cohort_id_generator(mode="str")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 description = "Python tools for modelling plant productivity and demography."
 license = "MIT"
 name = "pyrealm"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 
 dependencies = [
   "dacite (>1.6)",

--- a/pyrealm/demography/cohorts.py
+++ b/pyrealm/demography/cohorts.py
@@ -107,10 +107,13 @@ def create_cohorts(
     if np.any(dbh_value <= 0):
         raise ValueError("DBH values must be strictly positive")
 
-    if (not np.issubdtype(n_individuals.dtype, np.integer)) or np.any(
-        n_individuals <= 0
+    # For n_individuals, specifically allow empty arrays of any type but otherwise
+    # integers >= 0.
+    if n_individuals.size and (
+        (not np.issubdtype(n_individuals.dtype, np.integer))
+        or np.any(n_individuals < 0)
     ):
-        raise ValueError("The number of individuals must be positive integers")
+        raise ValueError("The number of individuals must be integers >= 0.")
 
     columns = {
         "pft_name": pft_name,

--- a/pyrealm/demography/cohorts.py
+++ b/pyrealm/demography/cohorts.py
@@ -98,7 +98,7 @@ def create_cohorts(
     if len(shape) > 1:
         raise ValueError("Inputs must be 1 dimensional arrays")
 
-    unknown_pfts = set(pft_name).difference(flora.name)
+    unknown_pfts = set(pft_name).difference(flora.pft_name)
     if unknown_pfts:
         raise ValueError(
             f"PFTs in cohort data not present in flora: {','.join(unknown_pfts)}"
@@ -126,7 +126,7 @@ def create_cohorts(
     # convert to pandas
     cohorts_df = Cohorts(columns)
 
-    cohorts = cohorts_df.merge(flora_df, left_on="pft_name", right_on="name")
+    cohorts = cohorts_df.merge(flora_df, on="pft_name")
     cohorts.insert(0, "cohort_id", [next(cid_generator) for idx in range(shape[0])])
 
     return cohorts

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -245,7 +245,7 @@ class CrownProfile(ToDataFrameMixin):
         # TODO: Need to do some form of validation here to check allometry and cohorts
         #       are congruent and sensible - maybe calculate allometry internally.
         #       This is only intended to work with the specific cohort DBH, so could
-        #       just check cohort_ids align across the two inputs.
+        #       just check cohort_id aligns across the two inputs.
 
         self.relative_crown_radius: NDArray[np.floating]
         """A 2D array of the relative crown radius of each stem at given heights"""
@@ -269,7 +269,7 @@ class CrownProfile(ToDataFrameMixin):
             # Check the allometry is 1D and matches the cohorts
             if allometry._ndims > 1:
                 raise ValueError("Provided allometry calculated using `at_dbh`.")
-            if not np.all(np.equal(allometry.cohort_ids, cohorts.cohort_id.to_numpy())):
+            if not np.all(np.equal(allometry.cohort_id, cohorts.cohort_id.to_numpy())):
                 raise ValueError("Provided allometry does not match cohorts.")
 
         # Validate z and set height_is_valid

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -101,44 +101,44 @@ class Flora(BaseModel):
       this is the rate at which total stem biomass turns over through branch loss.
     """
 
-    name: list[str] = ["default"]
+    name: tuple[str, ...] = ("default",)
     r"""The name of the plant functional type."""
-    a_hd: list[float] = [116.0]
+    a_hd: tuple[float, ...] = (116.0,)
     r"""Initial slope of height-diameter relationship (:math:`a`, -)"""
-    ca_ratio: list[float] = [390.43]
+    ca_ratio: tuple[float, ...] = (390.43,)
     r"""Initial ratio of crown area to stem cross-sectional area (:math:`c`, -)"""
-    h_max: list[float] = [25.33]
+    h_max: tuple[float, ...] = (25.33,)
     r"""Maximum tree height (:math:`H_m`, m)"""
-    rho_s: list[float] = [200.0]
+    rho_s: tuple[float, ...] = (200.0,)
     r"""Sapwood density (:math:`\rho_s`, kg Cm-3)"""
-    lai: list[float] = [1.8]
+    lai: tuple[float, ...] = (1.8,)
     """Leaf area index within the crown (:math:`L`,  -)"""
-    sla: list[float] = [14.0]
+    sla: tuple[float, ...] = (14.0,)
     r"""Specific leaf area (:math:`\sigma`,  m2 kg-1 C)"""
-    tau_f: list[float] = [4.0]
+    tau_f: tuple[float, ...] = (4.0,)
     r"""Foliage turnover time (:math:`\tau_f`,years)"""
-    tau_r: list[float] = [1.04]
+    tau_r: tuple[float, ...] = (1.04,)
     r"""Fine-root turnover time (:math:`\tau_r`,  years)"""
-    tau_b: list[float] = [np.inf]
+    tau_b: tuple[float, ...] = (np.inf,)
     r"""Branch turnover time (:math:`\tau_b`,  years)"""
-    par_ext: list[float] = [0.5]
+    par_ext: tuple[float, ...] = (0.5,)
     r"""Extinction coefficient of photosynthetically active radiation (PAR) (:math:`k`,
      -)"""
-    yld: list[float] = [0.6]
+    yld: tuple[float, ...] = (0.6,)
     r"""Yield factor (:math:`y`,  -)"""
-    zeta: list[float] = [0.17]
+    zeta: tuple[float, ...] = (0.17,)
     r"""Ratio of fine-root mass to foliage area (:math:`\zeta`, kg C m-2)"""
-    resp_r: list[float] = [0.913]
+    resp_r: tuple[float, ...] = (0.913,)
     r"""Fine-root specific respiration rate (:math:`r_r`, year-1)"""
-    resp_s: list[float] = [0.044]
+    resp_s: tuple[float, ...] = (0.044,)
     r"""Sapwood-specific respiration rate (:math:`r_s`,  year-1)"""
-    resp_f: list[float] = [0.1]
+    resp_f: tuple[float, ...] = (0.1,)
     r"""Foliage maintenance respiration fraction (:math:`r_f`,  -)"""
-    m: list[float] = [2]
+    m: tuple[float, ...] = (2,)
     r"""Crown shape parameter (:math:`m`, -)"""
-    n: list[float] = [5]
+    n: tuple[float, ...] = (5,)
     r"""Crown shape parameter (:math:`n`, -)"""
-    f_g: list[float] = [0.05]
+    f_g: tuple[float, ...] = (0.05,)
     r"""Crown gap fraction (:math:`f_g`, -)"""
 
     # This decorator order for computed fields is recommended by pydantic but mypy
@@ -146,23 +146,27 @@ class Flora(BaseModel):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def q_m(self) -> list[float]:
+    def q_m(self) -> tuple[float, ...]:
         """Scaling factor to derive maximum crown radius from crown area."""
 
-        # A bit odd here - the validator uses lists of values, but the functions use
+        # A bit odd here - the validator uses tuples of values, but the functions use
         # np.arrays. It makes more sense to keep those standalone functions as np inputs
         # so here we shimmy to np and back. The alternative is to use numpy-pydantic.
-        return calculate_crown_q_m(m=np.array(self.m), n=np.array(self.n)).tolist()
+        return tuple(
+            calculate_crown_q_m(m=np.array(self.m), n=np.array(self.n)).tolist()
+        )
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def z_max_prop(self) -> list[float]:
+    def z_max_prop(self) -> tuple[float, ...]:
         """Proportion of stem height at which maximum crown radius is found."""
 
         # See comment on q_m property.
-        return calculate_crown_z_max_proportion(
-            m=np.array(self.m), n=np.array(self.n)
-        ).tolist()
+        return tuple(
+            calculate_crown_z_max_proportion(
+                m=np.array(self.m), n=np.array(self.n)
+            ).tolist()
+        )
 
     @model_validator(mode="after")
     def model_validation(self, info: ValidationInfo) -> Self:

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -101,7 +101,7 @@ class Flora(BaseModel):
       this is the rate at which total stem biomass turns over through branch loss.
     """
 
-    name: tuple[str, ...] = ("default",)
+    pft_name: tuple[str, ...] = ("default",)
     r"""The name of the plant functional type."""
     a_hd: tuple[float, ...] = (116.0,)
     r"""Initial slope of height-diameter relationship (:math:`a`, -)"""

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -245,4 +245,4 @@ class Flora(BaseModel):
     def __repr__(self) -> str:
         # Overrides the default pydantic __repr__.
 
-        return f"Flora with {len(self.name)} PFTS: {','.join(self.name)}"
+        return f"Flora with {len(self.pft_name)} PFTS: {', '.join(self.pft_name)}"

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -715,7 +715,7 @@ class StemAllometry(ToDataFrameMixin):
     """
 
     _array_attrs: ClassVar[tuple[str, ...]] = (
-        "cohort_ids",
+        "cohort_id",
         "dbh",
         "stem_height",
         "crown_area",
@@ -745,7 +745,7 @@ class StemAllometry(ToDataFrameMixin):
         """An integer giving the dimensionality of the predictions."""
 
         # Allometry attributes
-        self.cohort_ids: NDArray[np.generic]
+        self.cohort_id: NDArray[np.generic]
         """An array of the cohort ID for each prediction."""
         self.dbh: NDArray[np.floating]
         """The diameter at breast height (m)"""
@@ -773,7 +773,7 @@ class StemAllometry(ToDataFrameMixin):
         if at_dbh is None:
             # If no at_dbh is provided, use the dbh values from the cohorts.
             self.dbh = cohorts.dbh_value.to_numpy()
-            self.cohort_ids = cohorts.cohort_id.to_numpy()
+            self.cohort_id = cohorts.cohort_id.to_numpy()
             self._at_dbh_set = False
             self._ndims = 1
         else:
@@ -784,13 +784,13 @@ class StemAllometry(ToDataFrameMixin):
                 raise ValueError("Values in at_dbh must be greater than zero.")
 
             # Broadcast DBH and cohort IDs to their outer product,
-            self.dbh, self.cohort_ids = np.broadcast_arrays(
+            self.dbh, self.cohort_id = np.broadcast_arrays(
                 at_dbh[:, None], cohorts.cohort_id.to_numpy()
             )
             self._at_dbh_set = True
             self._ndims = 2
 
-        self._cohort_ids = cohorts.cohort_id.to_numpy()
+        self._cohort_id = cohorts.cohort_id.to_numpy()
 
         self.stem_height = calculate_heights(
             h_max=cohorts.h_max.to_numpy(),
@@ -895,7 +895,7 @@ class StemAllocation(ToDataFrameMixin):
     """
 
     _array_attrs: ClassVar[tuple[str, ...]] = (
-        "cohort_ids",
+        "cohort_id",
         "whole_crown_gpp",
         "sapwood_respiration",
         "foliage_respiration",
@@ -919,7 +919,7 @@ class StemAllocation(ToDataFrameMixin):
 
         warn_experimental("StemAllocation")
 
-        self.cohort_ids: NDArray[np.generic]
+        self.cohort_id: NDArray[np.generic]
         """A numpy array of cohort IDs."""
         self._profile: bool
         """An boolean flag indicating if predictions are for a GPP profile."""
@@ -964,8 +964,8 @@ class StemAllocation(ToDataFrameMixin):
                 :, *[None] * allometry._ndims
             ] * np.ones_like(allometry.dbh)
 
-            self.cohort_ids = np.broadcast_to(
-                allometry.cohort_ids, self.whole_crown_gpp.shape
+            self.cohort_id = np.broadcast_to(
+                allometry.cohort_id, self.whole_crown_gpp.shape
             )
             self._ndims = allometry._ndims + 1
         else:
@@ -978,7 +978,7 @@ class StemAllocation(ToDataFrameMixin):
                     f"The GPP array shape ({whole_crown_gpp.shape})is not congruent "
                     f"with predicted allometry shape ({allometry.dbh.shape})."
                 )
-            self.cohort_ids = allometry.cohort_ids
+            self.cohort_id = allometry.cohort_id
             self._ndims = allometry._ndims
 
         # To handle GPP profiling, the allocation terms that do not rely on GPP -
@@ -1093,7 +1093,7 @@ class GrowthIncrements(ToDataFrameMixin):
     """
 
     _array_attrs: ClassVar[tuple[str, ...]] = (
-        "cohort_ids",
+        "cohort_id",
         "delta_dbh",
         "delta_stem_mass",
         "delta_foliage_mass",
@@ -1109,7 +1109,7 @@ class GrowthIncrements(ToDataFrameMixin):
         stem_allocation: StemAllocation,
         biomass_production: NDArray[np.floating] | None = None,
     ):
-        self.cohort_ids: NDArray[np.generic]
+        self.cohort_id: NDArray[np.generic]
         """A numpy array of cohort IDs."""
         self._profile: bool
         """An boolean flag indicating if predictions are for a GPP profile."""
@@ -1142,7 +1142,7 @@ class GrowthIncrements(ToDataFrameMixin):
         # Copy over attributes from stem_allocation
         self.profile = stem_allocation.profile
         self._ndims = stem_allocation._ndims
-        self.cohort_ids = stem_allocation.cohort_ids
+        self.cohort_id = stem_allocation.cohort_id
 
         turnover = (
             stem_allocation.fine_root_turnover

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -939,6 +939,8 @@ class StemAllocation(ToDataFrameMixin):
         """Allocation to leaf turnover (g C)"""
         self.fine_root_turnover: NDArray[np.floating]
         """Allocation to fine root turnover"""
+        self.branch_turnover: NDArray[np.floating]
+        """Allocation to branch turnover"""
         self.npp: NDArray[np.floating]
         """Net primary productivity (g C)"""
 

--- a/pyrealm_build_data/community/pfts.csv
+++ b/pyrealm_build_data/community/pfts.csv
@@ -1,3 +1,3 @@
-name,a_hd,ca_ratio,h_max,lai,par_ext,resp_f,resp_r,resp_s,rho_s,sla,tau_f,tau_r,yld,zeta,f_g,m,n,tau_rt,resp_rt,p_foliage_for_reproductive_tissue,gpp_topslice
+pft_name,a_hd,ca_ratio,h_max,lai,par_ext,resp_f,resp_r,resp_s,rho_s,sla,tau_f,tau_r,yld,zeta,f_g,m,n,tau_rt,resp_rt,p_foliage_for_reproductive_tissue,gpp_topslice
 test1,116.0,390.43,25.33,1.8,0.5,0.1,0.913,0.044,200.0,14.0,4.0,1.04,0.17,0.17,0.02,2,5,0,0,0,0
 test2,116.0,390.43,15.33,1.8,0.5,0.1,0.913,0.044,200.0,14.0,4.0,1.04,0.17,0.17,0.02,2,5,0,0,0,0

--- a/pyrealm_build_data/community/pfts_partial.csv
+++ b/pyrealm_build_data/community/pfts_partial.csv
@@ -1,3 +1,3 @@
-name,a_hd,ca_ratio,h_max,par_ext,resp_f,resp_r,resp_s,rho_s,sla,tau_f,tau_r,yld,zeta,m
+pft_name,a_hd,ca_ratio,h_max,par_ext,resp_f,resp_r,resp_s,rho_s,sla,tau_f,tau_r,yld,zeta,m
 test1,116.0,390.43,25.33,0.5,0.1,0.913,0.044,200.0,14.0,4.0,1.04,0.17,0.17,2
 test2,116.0,390.43,15.33,0.5,0.1,0.913,0.044,200.0,14.0,4.0,1.04,0.17,0.17,2

--- a/tests/unit/demography/conftest.py
+++ b/tests/unit/demography/conftest.py
@@ -20,6 +20,7 @@ def rtmodel_flora():
     # Map the PFT trait args from the R implementation to pyrealm
     pft_definitions = pft_definitions.rename(
         columns={
+            "name": "pft_name",
             "a": "a_hd",
             "cr": "ca_ratio",
             "Hm": "h_max",
@@ -100,7 +101,7 @@ def fixture_cohorts_and_allometry():
 
     # A simple community containing one sample stem, with an initial crown gap fraction
     # of zero.
-    flora = Flora(name=["test"], f_g=[0.0])
+    flora = Flora(pft_name=("test",), f_g=(0.0,))
     cid_gen = cohort_id_generator()
     cohorts = create_cohorts(
         pft_name=np.array(["test"] * 4),

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -137,7 +137,7 @@ def test_Canopy__init__():
     from pyrealm.demography.flora import Flora
     from pyrealm.demography.tmodel import StemAllometry
 
-    flora = Flora(name=["broadleaf", "conifer"], h_max=[30, 20])
+    flora = Flora(pft_name=("broadleaf", "conifer"), h_max=(30, 20))
 
     cid_gen = cohort_id_generator()
     cohorts = create_cohorts(
@@ -242,10 +242,10 @@ def test_fit_perfect_plasticity_approximation():
 
     # Set up the inputs.
     flora = Flora(
-        name=["a", "b", "c"],
-        h_max=list(h_max),
-        a_hd=list(a_hd),
-        ca_ratio=list(ca_ratio),
+        pft_name=("a", "b", "c"),
+        h_max=tuple(h_max),
+        a_hd=tuple(a_hd),
+        ca_ratio=tuple(ca_ratio),
     )
 
     cid_gen = cohort_id_generator()

--- a/tests/unit/demography/test_cohorts.py
+++ b/tests/unit/demography/test_cohorts.py
@@ -29,10 +29,16 @@ import pytest
             id="valid_with_community",
         ),
         pytest.param(
-            {"pft_name": ["name"], "dbh_value": [1.0], "n_individuals": [12.2]},
-            pytest.raises(ValueError),
-            "The number of individuals must be positive integers",
-            id="non_integer_n_individuals",
+            {"pft_name": ["name"], "dbh_value": [1.0], "n_individuals": [0]},
+            does_not_raise(),
+            None,
+            id="valid with no individuals",
+        ),
+        pytest.param(
+            {"pft_name": [], "dbh_value": [], "n_individuals": []},
+            does_not_raise(),
+            None,
+            id="valid with empty lists",
         ),
         pytest.param(
             {"pft_name": ["name"], "dbh_value": [-1.0], "n_individuals": [12]},
@@ -41,10 +47,16 @@ import pytest
             id="negative_dbh",
         ),
         pytest.param(
-            {"pft_name": ["name"], "dbh_value": [1.0], "n_individuals": [0]},
+            {"pft_name": ["name"], "dbh_value": [1.0], "n_individuals": [12.2]},
             pytest.raises(ValueError),
-            "The number of individuals must be positive integers",
-            id="no_individuals",
+            "The number of individuals must be integers >= 0",
+            id="non_integer_n_individuals",
+        ),
+        pytest.param(
+            {"pft_name": ["name"], "dbh_value": [1.0], "n_individuals": [-50]},
+            pytest.raises(ValueError),
+            "The number of individuals must be integers >= 0",
+            id="negative individuals",
         ),
         pytest.param(
             {"pft_name": ["name"], "dbh_value": [1.0], "n_individuals": [12, 12]},

--- a/tests/unit/demography/test_cohorts.py
+++ b/tests/unit/demography/test_cohorts.py
@@ -81,7 +81,7 @@ def test_create_cohorts(inputs, outcome, msg):
     from pyrealm.demography.cohorts import cohort_id_generator, create_cohorts
     from pyrealm.demography.flora import Flora
 
-    flora = Flora(name=["name"])
+    flora = Flora(pft_name=("name",))
     cid_gen = cohort_id_generator()
     inputs = {k: np.array(v) for k, v in inputs.items()}
 
@@ -124,7 +124,7 @@ def test_create_cohorts_from_csv(filename, outcome, expect_community):
 
     datapath = resources.files("pyrealm_build_data.community") / filename
     cid_gen = cohort_id_generator()
-    flora = Flora(name=["test1", "test2"])
+    flora = Flora(pft_name=("test1", "test2"))
 
     with outcome:
         cohort_data = create_cohorts_from_csv(
@@ -151,7 +151,7 @@ def test_Cohorts_with_Flora_extensibility():
     class FloraExtended(Flora):
         my_new_field: list[int] = [42]  # type: ignore[annotation-unchecked]  # noqa: RUF012
 
-    flora = FloraExtended(name=["test1", "test2"])
+    flora = FloraExtended(pft_name=("test1", "test2"))
 
     cohort_data = create_cohorts_from_csv(
         path=datapath, cid_generator=cid_gen, flora=flora

--- a/tests/unit/demography/test_flora.py
+++ b/tests/unit/demography/test_flora.py
@@ -18,7 +18,7 @@ def flora_data(mode: str, length: int, unequal: bool):
         return {}
 
     args: dict[str, tuple] = dict(
-        name=("defaults",),
+        pft_name=("defaults",),
         a_hd=(116.0,),
         ca_ratio=(390.43,),
         h_max=(15.33,),
@@ -163,7 +163,7 @@ def test_Flora_from_csv(filename, strict, outcome):
 
     with outcome:
         flora = Flora.from_csv(datapath, strict=strict)
-        assert flora.name == ("test1", "test2")
+        assert flora.pft_name == ("test1", "test2")
 
 
 def test_Flora_to_dataframe():
@@ -175,7 +175,7 @@ def test_Flora_to_dataframe():
 
     df = flora.to_dataframe()
 
-    assert df["name"].equals(pd.Series(["test1", "test2"]))
+    assert df["pft_name"].equals(pd.Series(["test1", "test2"]))
     assert df["a_hd"].equals(pd.Series([116.0, 116.0]))
 
 

--- a/tests/unit/demography/test_flora.py
+++ b/tests/unit/demography/test_flora.py
@@ -17,26 +17,26 @@ def flora_data(mode: str, length: int, unequal: bool):
     if mode == "empty":
         return {}
 
-    args: dict[str, list] = dict(
-        name=["defaults"],
-        a_hd=[116.0],
-        ca_ratio=[390.43],
-        h_max=[15.33],
-        lai=[1.8],
-        par_ext=[0.5],
-        resp_f=[0.1],
-        resp_r=[0.913],
-        resp_s=[0.044],
-        rho_s=[200.0],
-        sla=[14.0],
-        tau_f=[4.0],
-        tau_r=[1.04],
-        tau_b=[np.inf],
-        yld=[0.17],
-        zeta=[0.17],
-        f_g=[0.02],
-        m=[2],
-        n=[5],
+    args: dict[str, tuple] = dict(
+        name=("defaults",),
+        a_hd=(116.0,),
+        ca_ratio=(390.43,),
+        h_max=(15.33,),
+        lai=(1.8,),
+        par_ext=(0.5,),
+        resp_f=(0.1,),
+        resp_r=(0.913,),
+        resp_s=(0.044,),
+        rho_s=(200.0,),
+        sla=(14.0,),
+        tau_f=(4.0,),
+        tau_r=(1.04,),
+        tau_b=(np.inf,),
+        yld=(0.17,),
+        zeta=(0.17,),
+        f_g=(0.02,),
+        m=(2,),
+        n=(5,),
     )
 
     if mode == "partial":
@@ -122,8 +122,8 @@ def test_Flora(flora_data, mode, length, unequal, strict, outcome, msg):
         v = Flora.model_validate(flora_data, context={"strict": strict})
 
         # Missing fields from partial and empty modes are present and the right length
-        assert v.tau_f == [4.0] * length
-        assert v.tau_r == [1.04] * length
+        assert v.tau_f == (4.0,) * length
+        assert v.tau_r == (1.04,) * length
 
         # Computed fields are present
         assert hasattr(v, "q_m")
@@ -163,7 +163,7 @@ def test_Flora_from_csv(filename, strict, outcome):
 
     with outcome:
         flora = Flora.from_csv(datapath, strict=strict)
-        assert flora.name == ["test1", "test2"]
+        assert flora.name == ("test1", "test2")
 
 
 def test_Flora_to_dataframe():
@@ -189,7 +189,7 @@ def test_Flora_extensibility(flora_data, mode, length, unequal):
 
     # A new subclass with additional variables
     class FloraExtended(Flora):
-        my_new_field: list[int] = [42]  # type: ignore[annotation-unchecked]  # noqa: RUF012
+        my_new_field: tuple[int, ...] = (42,)
 
     # Strict mode still works
     with pytest.raises(ValidationError):
@@ -199,15 +199,15 @@ def test_Flora_extensibility(flora_data, mode, length, unequal):
     flora = FloraExtended.model_validate(flora_data)
 
     assert hasattr(flora, "my_new_field")
-    assert getattr(flora, "my_new_field") == [42, 42]
+    assert getattr(flora, "my_new_field") == (42, 42)
 
     # Check it works when data provided
-    flora_data["my_new_field"] = [1, 1]
+    flora_data["my_new_field"] = (1, 1)
 
     flora = FloraExtended.model_validate(flora_data)
 
     assert hasattr(flora, "my_new_field")
-    assert getattr(flora, "my_new_field") == [1, 1]
+    assert getattr(flora, "my_new_field") == (1, 1)
 
     # And that the field is present in the dataframe version.
     flora_df = flora.to_dataframe()

--- a/tests/unit/demography/test_tmodel.py
+++ b/tests/unit/demography/test_tmodel.py
@@ -514,7 +514,7 @@ def test_StemAllometry_StemAllocation_GrowthIncrements(
     # Generate cohort
     cid_gen = cohort_id_generator()
     cohorts = create_cohorts(
-        pft_name=np.array(rtmodel_flora.name),
+        pft_name=np.array(rtmodel_flora.pft_name),
         n_individuals=np.array([1, 1, 1]),
         dbh_value=rtmodel_data["dbh"][dbh_idx],
         cid_generator=cid_gen,
@@ -653,7 +653,7 @@ def test_StemAllocation_GPP_inputs(
     ## Generate cohort data and calculate the allometry and allocation
     cid_gen = cohort_id_generator()
     cohorts = create_cohorts(
-        pft_name=np.array(rtmodel_flora.name),
+        pft_name=np.array(rtmodel_flora.pft_name),
         n_individuals=np.array([1, 1, 1]),
         dbh_value=np.array([0.5, 0.5, 0.5]),
         flora=rtmodel_flora,

--- a/tests/unit/demography/test_tmodel.py
+++ b/tests/unit/demography/test_tmodel.py
@@ -533,7 +533,7 @@ def test_StemAllometry_StemAllocation_GrowthIncrements(
         for v in stem_allometry._array_attrs
         if v
         not in [
-            "cohort_ids",
+            "cohort_id",
             "crown_r0",
             "crown_z_max",
             "fine_root_mass",
@@ -575,7 +575,7 @@ def test_StemAllometry_StemAllocation_GrowthIncrements(
         for v in stem_allocation._array_attrs
         if v
         not in [
-            "cohort_ids",
+            "cohort_id",
             "foliage_respiration",
             "foliage_turnover",
             "fine_root_turnover",
@@ -666,7 +666,7 @@ def test_StemAllocation_GPP_inputs(
 
     # Check the attribute shape
     assert alloc.whole_crown_gpp.shape == exp_shape
-    assert alloc.cohort_ids.shape == exp_shape
+    assert alloc.cohort_id.shape == exp_shape
     assert alloc.foliage_respiration.shape == exp_shape
 
     # Check dataframe conversion and repr works


### PR DESCRIPTION
# Snagging for pyrealm v3.0.0 RC 2

This PR fixes issues with the new demography system from using it with the Virtual Ecosystem and sets up a new release candidate.

* Demography classes just use `cohort_id` as an attribute not a mix of  `cohort_id` and  `cohort_ids`
* Swaps `Flora` over to use tuples as defaults, not lists: they are supposed to be immutable and avoids issues with default factories. 
* The `Flora.name` attribute has been renamed to `Flora.pft_name`: more explicit and consistent with `create_cohorts`.
* Bumped RC version 

Fixes #695

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
