### PR TITLE
697 the pyrealm v300rc3 snagging list

### DIFF
--- a/docs/source/users/demography/allometry.md
+++ b/docs/source/users/demography/allometry.md
@@ -30,7 +30,7 @@ import numpy as np
 import pandas as pd
 
 from pyrealm.core.experimental import ExperimentalFeatureWarning
-from pyrealm.demography.flora import Flora
+from pyrealm.demography.flora import create_flora
 from pyrealm.demography.cohorts import create_cohorts, cohort_id_generator
 from pyrealm.demography.tmodel import StemAllometry
 
@@ -45,7 +45,7 @@ To generate allometric predictions under the T Model, we need to define a set of
 
 ```{code-cell} ipython3
 # Create a flora with 3 PFTs with different maximum heights
-flora = Flora(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30))
+flora = create_flora(dict(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30)))
 
 # Create an id generator.
 cid_generator = cohort_id_generator(mode="str")

--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -39,7 +39,7 @@ from matplotlib.patches import Polygon
 import numpy as np
 import pandas as pd
 
-from pyrealm.demography.flora import Flora
+from pyrealm.demography.flora import create_flora
 from pyrealm.demography.cohorts import create_cohorts, cohort_id_generator
 from pyrealm.demography.crown import CrownProfile
 from pyrealm.demography.canopy import Canopy
@@ -107,13 +107,15 @@ individual stems, grouped into 3 cohorts with different stem sizes and crown sha
 
 ```{code-cell} ipython3
 # Create a flora
-flora = Flora(
-    pft_name=("short", "tall"),
-    h_max=(15, 30),
-    m=(2, 2),
-    n=(4, 3),
-    f_g=(0, 0),
-    ca_ratio=(380, 500),
+flora = create_flora(
+    dict(
+        pft_name=("short", "tall"),
+        h_max=(15, 30),
+        m=(2, 2),
+        n=(4, 3),
+        f_g=(0, 0),
+        ca_ratio=(380, 500),
+    )
 )
 
 # Create an id generator.
@@ -377,13 +379,15 @@ and canopy gap fractions.
 
 ```{code-cell} ipython3
 # Define a flora with PFTs that have crown gap fractions
-gappy_flora = Flora(
-    pft_name=("short", "tall"),
-    h_max=(15, 30),
-    m=(2, 2),
-    n=(4, 3),
-    f_g=(0.1, 0.1),
-    ca_ratio=(380, 500),
+gappy_flora = create_flora(
+    dict(
+        pft_name=("short", "tall"),
+        h_max=(15, 30),
+        m=(2, 2),
+        n=(4, 3),
+        f_g=(0.1, 0.1),
+        ca_ratio=(380, 500),
+    )
 )
 
 # Define a community with three cohorts of stems with gappy canopies

--- a/docs/source/users/demography/carbon_allocation.md
+++ b/docs/source/users/demography/carbon_allocation.md
@@ -30,7 +30,7 @@ import numpy as np
 import pandas as pd
 
 from pyrealm.core.experimental import ExperimentalFeatureWarning
-from pyrealm.demography.flora import Flora
+from pyrealm.demography.flora import create_flora
 from pyrealm.demography.cohorts import create_cohorts, cohort_id_generator
 from pyrealm.demography.tmodel import (
     StemAllocation,
@@ -52,7 +52,7 @@ and their stem allometry:
 
 ```{code-cell} ipython3
 # Create a flora with 3 PFTs with different maximum heights
-flora = Flora(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30))
+flora = create_flora(dict(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30)))
 
 # Create an id generator.
 cid_generator = cohort_id_generator(mode="str")

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -41,7 +41,7 @@ from pyrealm.core.experimental import ExperimentalFeatureWarning
 from pyrealm.demography.flora import (
     calculate_crown_q_m,
     calculate_crown_z_max_proportion,
-    Flora,
+    create_flora,
 )
 
 from pyrealm.demography.cohorts import create_cohorts, cohort_id_generator
@@ -227,12 +227,14 @@ a `Flora` object using the PFTs.
 
 ```{code-cell} ipython3
 # Generate a Flora instance using those PFTs
-flora = Flora(
-    pft_name=("narrow", "medium", "wide"),
-    h_max=(20, 20, 20),
-    m=(1.5, 1.5, 4),
-    n=(1.5, 4, 1.5),
-    ca_ratio=(20, 500, 2000),
+flora = create_flora(
+    dict(
+        pft_name=("narrow", "medium", "wide"),
+        h_max=(20, 20, 20),
+        m=(1.5, 1.5, 4),
+        n=(1.5, 4, 1.5),
+        ca_ratio=(20, 500, 2000),
+    )
 )
 flora
 ```
@@ -240,9 +242,7 @@ flora
 The key canopy variables from the flora are:
 
 ```{code-cell} ipython3
-flora.to_dataframe()[
-    ["pft_name", "h_max", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]
-]
+flora[["pft_name", "h_max", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]]
 ```
 
 The next section of code generates the `StemAllometry` to use for the profiles.
@@ -388,7 +388,7 @@ crown area from the T Model allometry.
 
 ```{code-cell} ipython3
 # Calculate the crown profile across those heights for each PFT
-z_max = flora.z_max_prop * stem_height
+z_max = flora["z_max_prop"].to_numpy() * stem_height
 profile_at_zmax = CrownProfile(cohorts=cohorts, allometry=allometry, z=z_max)
 
 print(np.diag(profile_at_zmax.crown_radius**2 * np.pi))
@@ -403,13 +403,15 @@ below generates new profiles for a new set of PFTs that have similar crown area 
 but different shapes and gap fractions.
 
 ```{code-cell} ipython3
-flora = Flora(
-    pft_name=("no_gaps", "few_gaps", "many_gaps"),
-    h_max=(20, 20, 20),
-    m=(1.5, 1.5, 4.0),
-    n=(1.5, 4.0, 1.5),
-    f_g=(0.0, 0.1, 0.3),
-    ca_ratio=(380, 400, 420),
+flora = create_flora(
+    dict(
+        pft_name=("no_gaps", "few_gaps", "many_gaps"),
+        h_max=(20, 20, 20),
+        m=(1.5, 1.5, 4.0),
+        n=(1.5, 4.0, 1.5),
+        f_g=(0.0, 0.1, 0.3),
+        ca_ratio=(380, 400, 420),
+    )
 )
 
 # Create an id generator.
@@ -486,7 +488,9 @@ for f_g in np.linspace(0, 1, num=11):
 
     # Create a flora with a single PFT with current f_g and then generate a
     # stem allometry and crown profile
-    flora = Flora(pft_name=("pft",), h_max=(20,), m=(2,), n=(2,), f_g=(f_g,))
+    flora = create_flora(
+        dict(pft_name=("pft",), h_max=(20,), m=(2,), n=(2,), f_g=(f_g,))
+    )
 
     # Create the cohorts
     cohorts = create_cohorts(
@@ -582,8 +586,4 @@ _ = plt.legend(
     bbox_to_anchor=(0.5, 1.15),
     frameon=False,
 )
-```
-
-```{code-cell} ipython3
-
 ```

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -38,7 +38,7 @@ This page introduces the main components of the {mod}`~pyrealm.demography` modul
 ```{code-cell} ipython3
 import numpy as np
 
-from pyrealm.demography.flora import Flora
+from pyrealm.demography.flora import create_flora, load_flora_from_csv
 from pyrealm.demography.cohorts import (
     create_cohorts,
     create_cohorts_from_csv,
@@ -106,37 +106,35 @@ the PlantFATE model {cite}`joshi:2022a`.
 
 +++
 
-## The Flora class
+## The Flora object and `create_flora`
 
-The {class}`~pyrealm.demography.flora.Flora` class is used to create a set of PFTs
-that will be used in a demographic simulation. It can be created directly by providing
-a tuple of values for each trait: you must provide the same length list of values for
-each trait but if you omit some traits then they will be automatically populated
-from default values.
+The {class}`~pyrealm.demography.flora.Flora` class is simply a {class}`pandas.DataFrame`
+containing a validated set of plant functional type data that can be used in a
+demographic simulation. However, `Flora` objects should be created using the
+`create_flora` function, which is used to validate inputs and optionally populate
+missing traits from default values.
 
 ```{code-cell} ipython3
-flora = Flora(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30))
-flora
+flora = create_flora(dict(pft_name=("short", "medium", "tall"), h_max=(10, 20, 30)))
 ```
 
-You can use the  {meth}`~pyrealm.demography.core.ToDataFrameMixin.to_dataframe()` method
-of {class}`~pyrealm.demography.flora.Flora`  to export the trait data as a
-{class}`pandas.DataFrame`, making it easier to use for plotting or calculations outside
-of `pyrealm`.
+The resulting object is simply a dataframe, containing all of the required traits:
 
 ```{code-cell} ipython3
-flora.to_dataframe().transpose()
+flora.transpose()
 ```
 
 You can also create a `Flora` instance using PFT data stored in a [CSV
-file](./pfts.csv). Note that this CSV only provides some of the PFT traits, you can use
-`Flora.from_csv("pfts.csv", strict=True)` to require that the file provides all the
-traits.
+file](./pfts.csv).
 
 ```{code-cell} ipython3
-flora_from_csv = Flora.from_csv("pfts.csv")
-flora_from_csv
+flora_from_csv = load_flora_from_csv("pfts.csv")
+flora_from_csv.transpose()
 ```
+
+Note that this CSV only provides some of the PFT traits, you can use
+`load_flora_from_csv("pfts.csv", strict=True)` to require that the file provides all the
+traits.
 
 ## Plant Cohorts
 

--- a/docs/source/users/demography/light_capture.md
+++ b/docs/source/users/demography/light_capture.md
@@ -33,7 +33,7 @@ import warnings
 import numpy as np
 
 from pyrealm.core.experimental import ExperimentalFeatureWarning
-from pyrealm.demography.flora import Flora
+from pyrealm.demography.flora import create_flora
 from pyrealm.demography.cohorts import create_cohorts, cohort_id_generator
 from pyrealm.demography.tmodel import StemAllometry
 from pyrealm.demography.canopy import Canopy, CohortCanopyData
@@ -491,14 +491,16 @@ canopy model](./canopy.md) calculations.
 
 ```{code-cell} ipython3
 # Define a flora with PFTs that have crown gap fractions
-gappy_flora = Flora(
-    pft_name=("short", "tall"),
-    h_max=(15, 30),
-    m=(1.5, 1.5),
-    n=(3, 1.5),
-    par_ext=(0.5, 0.6),
-    f_g=(0.1, 0.1),
-    ca_ratio=(380, 500),
+gappy_flora = create_flora(
+    dict(
+        pft_name=("short", "tall"),
+        h_max=(15, 30),
+        m=(1.5, 1.5),
+        n=(3, 1.5),
+        par_ext=(0.5, 0.6),
+        f_g=(0.1, 0.1),
+        ca_ratio=(380, 500),
+    )
 )
 
 cid_generator = cohort_id_generator(mode="str")

--- a/pyrealm/demography/cohorts.py
+++ b/pyrealm/demography/cohorts.py
@@ -78,9 +78,6 @@ def create_cohorts(
             communities.
     """
 
-    # Define attributes
-    flora_df = flora.to_dataframe()
-
     # Validate the inputs - originally did this with pydantic, but support for numpy
     # and bypassing validation when using pydantic to load just ended up tying the
     # code in knots.
@@ -126,7 +123,7 @@ def create_cohorts(
     # convert to pandas
     cohorts_df = Cohorts(columns)
 
-    cohorts = cohorts_df.merge(flora_df, on="pft_name")
+    cohorts = cohorts_df.merge(flora, on="pft_name")
     cohorts.insert(0, "cohort_id", [next(cid_generator) for idx in range(shape[0])])
 
     return cohorts

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -77,7 +77,14 @@ def calculate_crown_z_max_proportion(
     return ((n - 1) / (m * n - 1)) ** (1 / n)
 
 
-class Flora(BaseModel):
+class Flora(pd.DataFrame):
+    """The Cohorts class.
+
+    The Flora class is simply an alias for a {class}`pandas.DataFrame`.
+    """
+
+
+class FloraValidator(BaseModel):
     """The Flora class.
 
     This dataclass implements the set of traits required to define a plant functional
@@ -203,46 +210,41 @@ class Flora(BaseModel):
 
         return self
 
-    @classmethod
-    def _from_file_data(cls, file_data: dict, strict: bool = False) -> Flora:
-        """Create a Flora object from a dictionary of data.
 
-        Args:
-            file_data: The payload from a data file defining plant functional types.
-            strict: Require that all traits are specified in the input data.
-        """
-        try:
-            flora = cls.model_validate(file_data, context={"strict": strict})
-        except ValidationError as excep:
-            raise excep
+def load_flora_from_csv(
+    path: Path, strict: bool = False, validator: type[FloraValidator] = FloraValidator
+) -> Flora:
+    """Create a Flora object from a CSV file.
 
-        return flora
+    Args:
+        path: A path to a CSV file of plant functional type definitions.
+        strict: Require that all traits are specified in the input file.
+        validator: A pydantic class used to validate the data.
+    """
 
-    @classmethod
-    def from_csv(cls, path: Path, strict: bool = False) -> Flora:
-        """Create a Flora object from a CSV file.
+    try:
+        data = pd.read_csv(path)
+    except (FileNotFoundError, pd.errors.ParserError) as excep:
+        raise excep
 
-        Args:
-            path: A path to a CSV file of plant functional type definitions.
-            strict: Require that all traits are specified in the input file.
-        """
+    return create_flora(data.to_dict(orient="list"), strict=strict, validator=validator)
 
-        try:
-            data = pd.read_csv(path)
-        except (FileNotFoundError, pd.errors.ParserError) as excep:
-            raise excep
 
-        return cls._from_file_data(data.to_dict(orient="list"), strict=strict)
+def create_flora(
+    data: dict,
+    strict: bool = False,
+    validator: type[FloraValidator] = FloraValidator,
+) -> Flora:
+    """Create a Flora object from a dictionary of data.
 
-    def to_dataframe(self) -> pd.DataFrame:
-        """Return the Flora data as a pandas DataFrame.
+    Args:
+        data: A dictionary providing plant functional trait data.
+        strict: Require that all traits are specified in the input data.
+        validator: A pydantic class used to validate the data.
+    """
+    try:
+        validated_data = validator.model_validate(data, context={"strict": strict})
+    except ValidationError as excep:
+        raise excep
 
-        This is primarily used to store the flora data within the Cohorts class and
-        allow it to be easily merged onto cohort data, which specifies the PFT name.
-        """
-        return pd.DataFrame(self.model_dump())
-
-    def __repr__(self) -> str:
-        # Overrides the default pydantic __repr__.
-
-        return f"Flora with {len(self.pft_name)} PFTS: {', '.join(self.pft_name)}"
+    return Flora(validated_data.model_dump())

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -1,8 +1,11 @@
-"""The flora module implements:
+"""The flora module provides:
 
-* The Flora class. This is pydantic data model that provides a set of plant functional
-  types (PFT), defined as a set of functional traits for each PFT. The class defines a
-  specific set of traits used for demographic modelling in pyrealm, mostly the
+* The :class:`Flora` class. This is simply an alias for the :class:`pandas.DataFrame`
+  class, used to indicate a dataframe with a guaranteed set of fields.
+
+* The FloraValidator class. This is pydantic data model that provides a set of plant
+  functional types (PFT), defined as a set of functional traits for each PFT. The class
+  defines a specific set of traits used for demographic modelling in pyrealm, mostly the
   parameterisation of the T Model, but also some additional parameters for modelling
   crown shape.
 
@@ -11,10 +14,16 @@
   filled in using the default values, unless the model context specifies 'strict'
   validation when the user must provide all fields.
 
-  The class provides `from_csv` to generate an instance from trait data stored in a CSV
-  file.
-
 * Two functions to calculate computed traits (``q_m`` and ``z_max_prop``).
+
+In practice, instances of the ``Flora`` class should be created using either:
+
+* :meth:`create_flora` or
+* :meth:`load_flora_from_csv`.
+
+These functions are wrappers around the ``FloraValidator`` class that check the input
+data pass validation and provides the ``strict`` option to require the input data
+provides all required fields, rather than filling them from defaults.
 """  # noqa: D415
 
 

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -880,6 +880,10 @@ class StemAllocation(ToDataFrameMixin):
        values but will calculate allocation values for all combinations of DBH, cohort
        and GPP.
 
+    GPP values cannot be negative but _can_ be zero, which might be expected under
+    winter conditions for example. The calculated NPP can also be negative where the GPP
+    is insufficient to cover respiration costs.
+
     Args:
         cohorts: An instance of :class:`~pyrealm.demography.cohorts.Cohorts`.
         allometry: An instance of :class:`~pyrealm.demography.tmodel.StemAllometry`.
@@ -950,8 +954,8 @@ class StemAllocation(ToDataFrameMixin):
         # Check we have an array of strictly positive values
         if not isinstance(whole_crown_gpp, np.ndarray):
             raise ValueError("The whole_crown_gpp value must be a numpy array.")
-        if np.any(whole_crown_gpp <= 0):
-            raise ValueError("Values in whole_crown_gpp must be greater than zero.")
+        if np.any(whole_crown_gpp < 0):
+            raise ValueError("Values in whole_crown_gpp cannot be negative.")
 
         if self.profile:
             # In profiling mode, a prediction is made at each GPP for each allometry
@@ -1084,10 +1088,14 @@ class GrowthIncrements(ToDataFrameMixin):
     NPP to allocate carbon to other pools such as VOC emissions, soil exudates and
     non-structural carbohydrates.
 
+    Note that growth increments can be negative if the biomass production is itself
+    negative, for example because GPP was insufficient to cover respiration costs, or
+    because the values are insufficient to cover turnover costs.
+
     Args:
         cohorts: A set of cohorts
         allometry: The current stem allometry for those cohorts
-        gpp_allocation: An allocation of whole crown GPP for those cohorts.
+        stem_allocation: An StemAllocation object providing NPP and turnover costs.
         biomass_production: An optional array of biomass production values, used to
             override the NPP estimate in ``gpp_allocation``.
     """

--- a/tests/array_inputs/overrides.py
+++ b/tests/array_inputs/overrides.py
@@ -39,7 +39,7 @@ SKIP_METHODS = [
     # OK - this is really problematic. Array auto-discovery gets hung up on the
     # internals of pydantic - not sure the greedy approach to what gets tested is
     # sustainable.
-    "Flora.__repr_args__",
+    "FloraValidator.__repr_args__",
     # Something about pandas methods on Cohort objects also triggers - these are
     # explicitly blocked in utils.get_method_list rather than handling each one here.
     "create_cohorts",

--- a/tests/unit/demography/conftest.py
+++ b/tests/unit/demography/conftest.py
@@ -48,7 +48,7 @@ def rtmodel_flora():
     pft_definitions["p_foliage_for_reproductive_tissue"] = 0
     pft_definitions["gpp_topslice"] = 0
 
-    return create_flora(**pft_definitions.to_dict(orient="list"))
+    return create_flora(pft_definitions.to_dict(orient="list"))
 
 
 @pytest.fixture

--- a/tests/unit/demography/conftest.py
+++ b/tests/unit/demography/conftest.py
@@ -11,7 +11,7 @@ import pytest
 def rtmodel_flora():
     """Generates a flora object from the rtmodel test definitions."""
 
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
 
     # Load the PFT definitions and rename to pyrealm attributes
     pfts_path = resources.files("pyrealm_build_data.t_model") / "pft_definitions.csv"
@@ -48,7 +48,7 @@ def rtmodel_flora():
     pft_definitions["p_foliage_for_reproductive_tissue"] = 0
     pft_definitions["gpp_topslice"] = 0
 
-    return Flora(**pft_definitions.to_dict(orient="list"))
+    return create_flora(**pft_definitions.to_dict(orient="list"))
 
 
 @pytest.fixture
@@ -96,12 +96,12 @@ def fixture_cohorts_and_allometry():
     """A fixture providing a simple community."""
 
     from pyrealm.demography.cohorts import cohort_id_generator, create_cohorts
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
     from pyrealm.demography.tmodel import StemAllometry
 
     # A simple community containing one sample stem, with an initial crown gap fraction
     # of zero.
-    flora = Flora(pft_name=("test",), f_g=(0.0,))
+    flora = create_flora(dict(pft_name=("test",), f_g=(0.0,)))
     cid_gen = cohort_id_generator()
     cohorts = create_cohorts(
         pft_name=np.array(["test"] * 4),

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -134,10 +134,10 @@ def test_Canopy__init__():
 
     from pyrealm.demography.canopy import Canopy
     from pyrealm.demography.cohorts import cohort_id_generator, create_cohorts
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
     from pyrealm.demography.tmodel import StemAllometry
 
-    flora = Flora(pft_name=("broadleaf", "conifer"), h_max=(30, 20))
+    flora = create_flora(dict(pft_name=("broadleaf", "conifer"), h_max=(30, 20)))
 
     cid_gen = cohort_id_generator()
     cohorts = create_cohorts(
@@ -226,7 +226,7 @@ def test_fit_perfect_plasticity_approximation():
 
     from pyrealm.demography.canopy import fit_perfect_plasticity_approximation
     from pyrealm.demography.cohorts import cohort_id_generator, create_cohorts
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
     from pyrealm.demography.tmodel import StemAllometry, calculate_dbh_from_height
 
     # Calculate DBH from target stem heights
@@ -241,11 +241,13 @@ def test_fit_perfect_plasticity_approximation():
     ca_ratio = (4 * a_hd * area) / (np.pi * stem_height * dbh)
 
     # Set up the inputs.
-    flora = Flora(
-        pft_name=("a", "b", "c"),
-        h_max=tuple(h_max),
-        a_hd=tuple(a_hd),
-        ca_ratio=tuple(ca_ratio),
+    flora = create_flora(
+        dict(
+            pft_name=("a", "b", "c"),
+            h_max=tuple(h_max),
+            a_hd=tuple(a_hd),
+            ca_ratio=tuple(ca_ratio),
+        )
     )
 
     cid_gen = cohort_id_generator()

--- a/tests/unit/demography/test_cohorts.py
+++ b/tests/unit/demography/test_cohorts.py
@@ -79,9 +79,9 @@ import pytest
 def test_create_cohorts(inputs, outcome, msg):
     """Test the Cohorts validation."""
     from pyrealm.demography.cohorts import cohort_id_generator, create_cohorts
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
 
-    flora = Flora(pft_name=("name",))
+    flora = create_flora(dict(pft_name=("name",)))
     cid_gen = cohort_id_generator()
     inputs = {k: np.array(v) for k, v in inputs.items()}
 
@@ -120,11 +120,11 @@ def test_create_cohorts_from_csv(filename, outcome, expect_community):
         cohort_id_generator,
         create_cohorts_from_csv,
     )
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
 
     datapath = resources.files("pyrealm_build_data.community") / filename
     cid_gen = cohort_id_generator()
-    flora = Flora(pft_name=("test1", "test2"))
+    flora = create_flora(dict(pft_name=("test1", "test2")))
 
     with outcome:
         cohort_data = create_cohorts_from_csv(
@@ -142,16 +142,16 @@ def test_Cohorts_with_Flora_extensibility():
         cohort_id_generator,
         create_cohorts_from_csv,
     )
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import FloraValidator, create_flora
 
     cid_gen = cohort_id_generator()
     datapath = resources.files("pyrealm_build_data.community") / "cohorts.csv"
 
     # A new subclass with additional variables
-    class FloraExtended(Flora):
+    class FloraExtended(FloraValidator):
         my_new_field: list[int] = [42]  # type: ignore[annotation-unchecked]  # noqa: RUF012
 
-    flora = FloraExtended(pft_name=("test1", "test2"))
+    flora = create_flora(dict(pft_name=("test1", "test2")), validator=FloraExtended)
 
     cohort_data = create_cohorts_from_csv(
         path=datapath, cid_generator=cid_gen, flora=flora

--- a/tests/unit/demography/test_crown.py
+++ b/tests/unit/demography/test_crown.py
@@ -296,10 +296,10 @@ def test_calculate_relative_crown_radius_at_z_values_clipping(m, n):
     from pyrealm.demography.crown import (
         calculate_relative_crown_radius_at_z,
     )
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import create_flora
 
     # Default PFT settings
-    flora = Flora(name=["test"], m=[m], n=[n])
+    flora = create_flora(dict(name=["test"], m=[m], n=[n]))
     # Get the relative radius at that heights of the crown z_max values
     z_max_prop = flora.z_max_prop[0]
     q_z_values = calculate_relative_crown_radius_at_z(

--- a/tests/unit/demography/test_flora.py
+++ b/tests/unit/demography/test_flora.py
@@ -104,35 +104,64 @@ def flora_data(mode: str, length: int, unequal: bool):
         ),
     ),
 )
-def test_Flora(flora_data, mode, length, unequal, strict, outcome, msg):
-    """Test the validation for Flora.
+class TestFloraValidation:
+    """Test validation directly and through create_flora."""
 
-    Checks the strict and lax modes work as expected with empty, partial and full inputs
-    and checks the unequal length validation works.
-    """
+    def test_FloraValidator(
+        self, flora_data, mode, length, unequal, strict, outcome, msg
+    ):
+        """Test the FloraValidator.
 
-    from pyrealm.demography.flora import Flora
+        Checks the strict and lax modes work as expected with empty, partial and full
+        inputs and checks the unequal length validation works.
+        """
 
-    # Would like to use spy here to validate that field validation failures exit before
-    # running custom model validation, but the line below always seems to return
-    # call_count = 0
-    # spy = mocker.spy(Flora, "strict_validation")
+        from pyrealm.demography.flora import FloraValidator
 
-    with outcome as err_handler:
-        v = Flora.model_validate(flora_data, context={"strict": strict})
+        # Would like to use spy here to validate that field validation failures exit
+        # before running custom model validation, but the line below always seems to
+        # return call_count = 0
+        # spy = mocker.spy(Flora, "strict_validation")
 
-        # Missing fields from partial and empty modes are present and the right length
-        assert v.tau_f == (4.0,) * length
-        assert v.tau_r == (1.04,) * length
+        with outcome as err_handler:
+            v = FloraValidator.model_validate(flora_data, context={"strict": strict})
 
-        # Computed fields are present
-        assert hasattr(v, "q_m")
-        assert hasattr(v, "z_max_prop")
+            # Missing fields from partial and empty modes are present and the right
+            # length
+            assert v.tau_f == (4.0,) * length
+            assert v.tau_r == (1.04,) * length
 
-        return
+            # Computed fields are present
+            assert hasattr(v, "q_m")
+            assert hasattr(v, "z_max_prop")
 
-    # Check errors raise the expected message
-    assert err_handler.match(msg)
+            return
+
+        # Check errors raise the expected message
+        assert err_handler.match(msg)
+
+    def test_create_flora(
+        self, flora_data, mode, length, unequal, strict, outcome, msg
+    ):
+        """Test the create_flora wrapper function using the same cases."""
+        from pyrealm.demography.flora import create_flora
+
+        with outcome as err_handler:
+            v = create_flora(flora_data, strict=strict)
+
+            # Missing fields from partial and empty modes are present and the right
+            # length
+            assert v["tau_f"].equals(pd.Series([4.0] * length))
+            assert v["tau_r"].equals(pd.Series([1.04] * length))
+
+            # Computed fields are present
+            assert "q_m" in v.columns
+            assert "z_max_prop" in v.columns
+
+            return
+
+        # Check errors raise the expected message
+        assert err_handler.match(msg)
 
 
 @pytest.mark.parametrize(
@@ -156,27 +185,15 @@ def test_Flora(flora_data, mode, length, unequal, strict, outcome, msg):
     ],
 )
 def test_Flora_from_csv(filename, strict, outcome):
-    """Test CSV loading."""
-    from pyrealm.demography.flora import Flora
+    """Test CSV loading, handling main error cases."""
+    from pyrealm.demography.flora import load_flora_from_csv
 
     datapath = resources.files("pyrealm_build_data.community") / filename
 
     with outcome:
-        flora = Flora.from_csv(datapath, strict=strict)
-        assert flora.pft_name == ("test1", "test2")
-
-
-def test_Flora_to_dataframe():
-    """Test conversion to dataframe."""
-    from pyrealm.demography.flora import Flora
-
-    datapath = resources.files("pyrealm_build_data.community") / "pfts.csv"
-    flora = Flora.from_csv(datapath)
-
-    df = flora.to_dataframe()
-
-    assert df["pft_name"].equals(pd.Series(["test1", "test2"]))
-    assert df["a_hd"].equals(pd.Series([116.0, 116.0]))
+        flora = load_flora_from_csv(datapath, strict=strict)
+        assert flora["pft_name"].equals(pd.Series(["test1", "test2"]))
+        assert flora["a_hd"].equals(pd.Series([116.0, 116.0]))
 
 
 @pytest.mark.parametrize(
@@ -185,32 +202,41 @@ def test_Flora_to_dataframe():
 )
 def test_Flora_extensibility(flora_data, mode, length, unequal):
     """Test the extensibility of the Flora model."""
-    from pyrealm.demography.flora import Flora
+    from pyrealm.demography.flora import FloraValidator, create_flora
 
     # A new subclass with additional variables
-    class FloraExtended(Flora):
+    class FloraValidatorExtended(FloraValidator):
         my_new_field: tuple[int, ...] = (42,)
 
-    # Strict mode still works
+    # Strict mode still works both with direct usage and when passing in to create_flora
     with pytest.raises(ValidationError):
-        flora = FloraExtended.model_validate(flora_data, context={"strict": True})
+        flora = FloraValidatorExtended.model_validate(
+            flora_data, context={"strict": True}
+        )
+
+    with pytest.raises(ValidationError):
+        flora = create_flora(flora_data, strict=True, validator=FloraValidatorExtended)
 
     # Create an instance to check defaults are filled in when not strict
-    flora = FloraExtended.model_validate(flora_data)
+    flora = FloraValidatorExtended.model_validate(flora_data)
 
     assert hasattr(flora, "my_new_field")
     assert getattr(flora, "my_new_field") == (42, 42)
 
+    flora = create_flora(flora_data, validator=FloraValidatorExtended)
+
+    assert "my_new_field" in flora.columns
+    assert flora["my_new_field"].equals(pd.Series([42, 42]))
+
     # Check it works when data provided
     flora_data["my_new_field"] = (1, 1)
 
-    flora = FloraExtended.model_validate(flora_data)
+    flora = FloraValidatorExtended.model_validate(flora_data)
 
     assert hasattr(flora, "my_new_field")
     assert getattr(flora, "my_new_field") == (1, 1)
 
-    # And that the field is present in the dataframe version.
-    flora_df = flora.to_dataframe()
+    flora = create_flora(flora_data, validator=FloraValidatorExtended)
 
-    assert "my_new_field" in flora_df
-    assert flora_df["my_new_field"].equals(pd.Series([1, 1]))
+    assert "my_new_field" in flora.columns
+    assert flora["my_new_field"].equals(pd.Series([1, 1]))

--- a/tests/unit/demography/test_tmodel.py
+++ b/tests/unit/demography/test_tmodel.py
@@ -674,3 +674,43 @@ def test_StemAllocation_GPP_inputs(
         df = alloc.to_dataframe()
         assert df.shape == (df_rows, len(alloc._array_attrs))
         repr(alloc)
+
+
+def test_StemAllocation_zero_gpp(rtmodel_flora):
+    """Test the predictions of StemAllocation and GrowthIncrements with zero GPP.
+
+    This is specifically to check that the edge case of zero GPP - which is a possible
+    input under extreme conditions - leads to finite predictions. These lead to negative
+    NPP and hence negative growth increments but this checks that the values are real
+    and not NaN or infinite.
+    """
+
+    from pyrealm.demography.cohorts import cohort_id_generator, create_cohorts
+    from pyrealm.demography.tmodel import (
+        GrowthIncrements,
+        StemAllocation,
+        StemAllometry,
+    )
+
+    ## Generate cohort data and calculate the allometry and allocation
+    cid_gen = cohort_id_generator()
+    cohorts = create_cohorts(
+        pft_name=np.array(rtmodel_flora.pft_name),
+        n_individuals=np.array([1, 1, 1]),
+        dbh_value=np.array([0.5, 0.5, 0.5]),
+        flora=rtmodel_flora,
+        cid_generator=cid_gen,
+    )
+    allom = StemAllometry(cohorts=cohorts)
+
+    alloc = StemAllocation(
+        cohorts=cohorts, allometry=allom, whole_crown_gpp=np.zeros(3)
+    )
+
+    for fld in (a for a in alloc._array_attrs if not a == "cohort_id"):
+        assert np.all(np.isfinite(getattr(alloc, fld)))
+
+    growth = GrowthIncrements(cohorts=cohorts, allometry=allom, stem_allocation=alloc)
+
+    for fld in (a for a in growth._array_attrs if not a == "cohort_id"):
+        assert np.all(np.isfinite(getattr(growth, fld)))


### PR DESCRIPTION
# Description

This PR does two things:

* The StemAllocation class no longer forbids GPP = 0. GPP still has to be >=0 but zero productivity is a possibility. A test is added to check that passing zero into StemAllocation and GrowthIncrements gives actual values (positive or negative) and not `np.nan` or `np.inf`.

* The Flora system is rejigged - the pydantic `Flora` class is renamed to `FloraValidator` and the `create_flora` function is used to apply the validator to inputs and return a `Flora` object, which is simply a label for a pandas DataFrame. The `create_flora` function allows strict and relaxed validation and also allows the validator to be altered, to allow use of extended `FloraValidator` subclasses.

    The main reason for this change is to limit how long the flora data spends as a pydantic model and convert it early into a data frame, which is the main usage model.

Fixes #697

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
